### PR TITLE
Listing renders, ATTOM + HouseCanary premium tier, and privacy-safe Deal Room

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 
 A full-stack aggregator dashboard for new construction townhomes in the greater Charlotte, NC area, with an optional private Gmail ingestion mode.
 
-## Screenshots
-
-**Listings — every source in one grid, with live price-cut alerts**
-![Listings](docs-assets/01-listings.png)
-
-**My Tours — a personal board for places you visit or are considering**
-![My Tours](docs-assets/04-my-tours.png)
-
-**Listing detail — price history + one-tap tracking & contact**
-![Detail](docs-assets/03-detail-modal.png)
-
 ## What it does
 
 - **Aggregates** listings from Zillow, Realtor.com, Opendoor, Homes.com, NewHomeSource, and direct builder websites (D.R. Horton, Lennar, Ryan Homes, Meritage, Eastwood, Smith Douglas, and more)

--- a/client/src/components/DealRoom.jsx
+++ b/client/src/components/DealRoom.jsx
@@ -1,6 +1,33 @@
-import { Lock, ShieldAlert } from 'lucide-react';
+import { useState, useMemo } from 'react';
+import { Lock, Unlock, ShieldAlert, Calculator } from 'lucide-react';
+import { IS_STATIC } from '../staticData';
 
-export default function DealRoom() {
+// The public static site never ships underwriting or benchmark data — the
+// private tier requires the local server (research.json is gitignored and its
+// API route is loopback-gated). No personal numbers live in this file: the
+// benchmark comes from research.your_deal at runtime.
+
+const fmt = n => (n || n === 0) ? `$${Math.round(n).toLocaleString()}` : '—';
+
+function underwrite(d, assumptions) {
+  const a = assumptions || {};
+  const rate = (a.rate_investment || 6.65) / 100 / 12;
+  const n = (a.loan_term_years || 30) * 12;
+  const effective = d.price - (d.incentive || 0);
+  const loan = effective * (1 - (a.down_payment_pct || 20) / 100);
+  const pi = loan * (rate * Math.pow(1 + rate, n)) / (Math.pow(1 + rate, n) - 1);
+  const taxMonthly = (d.taxAnnual || effective * 0.0098) / 12;
+  const insMonthly = (a.insurance_annual || 1500) / 12;
+  const piti = pi + taxMonthly + insMonthly + (d.hoa || a.hoa_monthly_default || 220);
+  const rent = d.rent || 0;
+  const grossYield = effective > 0 ? (rent * 12 / effective) * 100 : 0;
+  const cashFlow = rent * 0.9 - piti; // 5% vacancy + 5% maintenance
+  const leasebackValue = rent * (d.leaseMonths || 0);
+  const ppsf = d.sqft ? effective / d.sqft : null;
+  return { effective, piti: Math.round(piti), grossYield: Math.round(grossYield * 100) / 100, cashFlow: Math.round(cashFlow), leasebackValue, ppsf: ppsf ? Math.round(ppsf) : null };
+}
+
+function StaticStub() {
   return (
     <div className="max-w-xl mx-auto py-16">
       <div className="bg-white border border-amber-200 rounded-xl p-6 text-center shadow-sm">
@@ -14,6 +41,89 @@ export default function DealRoom() {
           <ShieldAlert className="w-4 h-4 shrink-0" />
           Keep contracts, negotiation notes, financial assumptions, and private source material outside the public repository and Pages build.
         </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DealRoom({ market, research }) {
+  const [d, setD] = useState({ address: '', price: 400000, incentive: 0, rent: 2500, leaseMonths: 12, hoa: 250, taxAnnual: 3100, sqft: 1600 });
+
+  const assumptions = market?.assumptions;
+  // Benchmark comes from the private research file, served only over loopback.
+  const yd = research?.your_deal;
+  const bench = useMemo(() => yd ? underwrite({
+    price: yd.price, incentive: yd.incentive, rent: yd.leaseback_rent_monthly,
+    leaseMonths: 12, hoa: yd.hoa_monthly, taxAnnual: yd.tax_annual, sqft: yd.sqft,
+  }, assumptions) : null, [yd, assumptions]);
+  const result = useMemo(() => underwrite(d, assumptions), [d, assumptions]);
+
+  if (IS_STATIC) return <StaticStub />;
+
+  const num = (key, label, step = 1000) => (
+    <label className="block">
+      <span className="text-xs text-gray-500">{label}</span>
+      <input type="number" step={step} value={d[key]} onChange={e => setD({ ...d, [key]: parseFloat(e.target.value) || 0 })}
+        className="w-full px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+    </label>
+  );
+
+  const beats = bench && result.effective / (d.sqft || 1) <= bench.effective / (yd.sqft || 1) && result.grossYield >= bench.grossYield;
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-2">
+        <Unlock className="w-4 h-4 text-green-600" />
+        <h2 className="text-base font-bold text-gray-900">Deal Room — private underwriting (local server only)</h2>
+      </div>
+
+      {!yd && (
+        <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3">
+          Benchmark unavailable — the private research API is disabled. Set <code>ALLOW_PRIVATE_LOCAL=true</code> in <code>server/.env</code> and
+          keep <code>server/data/research.json</code> in place (it is gitignored) to compare deals against your signed benchmark.
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 space-y-3">
+          <label className="block">
+            <span className="text-xs text-gray-500">Address / label</span>
+            <input value={d.address} onChange={e => setD({ ...d, address: e.target.value })} placeholder="Property to underwrite"
+              className="w-full px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {num('price', 'Asking price')}
+            {num('incentive', 'Incentives ($)')}
+            {num('rent', 'Rent / leaseback $/mo', 50)}
+            {num('leaseMonths', 'Leaseback months', 1)}
+            {num('hoa', 'HOA $/mo', 10)}
+            {num('taxAnnual', 'Tax $/yr', 100)}
+            {num('sqft', 'Sq ft', 10)}
+          </div>
+        </section>
+
+        <section className={`rounded-xl border p-4 ${beats ? 'bg-green-50 border-green-200' : 'bg-amber-50 border-amber-200'}`}>
+          <div className="flex items-center gap-2 mb-2">
+            <Calculator className="w-4 h-4 text-gray-600" />
+            <h3 className="text-sm font-semibold text-gray-800">{d.address || 'This deal'}</h3>
+          </div>
+          <table className="w-full text-sm">
+            <thead><tr className="text-xs text-gray-500"><th className="text-left font-medium py-1">Metric</th><th className="text-right font-medium">This deal</th><th className="text-right font-medium">Your benchmark</th></tr></thead>
+            <tbody className="text-gray-800">
+              <tr><td className="py-1 text-gray-500">Effective price</td><td className="text-right font-semibold">{fmt(result.effective)}</td><td className="text-right">{bench ? fmt(bench.effective) : '—'}</td></tr>
+              <tr><td className="py-1 text-gray-500">$/sqft (effective)</td><td className="text-right font-semibold">{result.ppsf ? `$${result.ppsf}` : '—'}</td><td className="text-right">{bench?.ppsf ? `$${bench.ppsf}` : '—'}</td></tr>
+              <tr><td className="py-1 text-gray-500">PITI + HOA /mo</td><td className="text-right font-semibold">{fmt(result.piti)}</td><td className="text-right">{bench ? fmt(bench.piti) : '—'}</td></tr>
+              <tr><td className="py-1 text-gray-500">Gross yield</td><td className="text-right font-semibold">{result.grossYield}%</td><td className="text-right">{bench ? `${bench.grossYield}%` : '—'}</td></tr>
+              <tr><td className="py-1 text-gray-500">Cash flow /mo (est)</td><td className="text-right font-semibold">{fmt(result.cashFlow)}</td><td className="text-right">{bench ? fmt(bench.cashFlow) : '—'}</td></tr>
+              <tr><td className="py-1 text-gray-500">Leaseback value</td><td className="text-right font-semibold">{fmt(result.leasebackValue)}</td><td className="text-right">{bench ? fmt(bench.leasebackValue) : '—'}</td></tr>
+            </tbody>
+          </table>
+          {bench && (
+            <p className={`text-xs font-medium rounded-lg p-2 mt-3 ${beats ? 'text-green-800 bg-green-100' : 'text-amber-800 bg-amber-100'}`}>
+              {beats ? '✓ Beats your benchmark on $/sqft and yield' : 'Does not beat your benchmark on both $/sqft and yield — negotiate or pass'}
+            </p>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/client/src/components/ResearchTab.jsx
+++ b/client/src/components/ResearchTab.jsx
@@ -24,12 +24,14 @@ export default function ResearchTab({ research }) {
     negotiation_playbook, best_builders_to_talk_to = [],
     upside_2027, contract_red_flags, rental_playbook, tripointe_roster, tour_archive, records_toolkit,
     key_insights, deal_programs, api_catalog, monetization, public_data_stack,
+    premium_data, competitive_edge, product_roadmap,
   } = research;
 
   const RATING_STYLE = { 'Very high': 'bg-green-100 text-green-800 font-semibold', 'High': 'bg-green-50 text-green-700', 'Med': 'bg-gray-100 text-gray-600', 'Low': 'bg-gray-50 text-gray-400' };
 
   const API_STATUS_STYLE = {
     'ready-to-wire': 'bg-green-100 text-green-800',
+    'wired-needs-key': 'bg-purple-100 text-purple-800',
     'if-monetized': 'bg-amber-100 text-amber-800',
     'needs-partner': 'bg-blue-100 text-blue-800',
     'caution-tos': 'bg-red-100 text-red-700',
@@ -431,11 +433,88 @@ export default function ResearchTab({ research }) {
         </section>
       )}
 
+      {/* Premium data providers — ATTOM vs HouseCanary */}
+      {premium_data && (
+        <section className="bg-white rounded-xl border border-purple-200 shadow-sm p-4">
+          <h3 className="text-sm font-semibold text-gray-700 mb-1.5">💎 Premium data tier — ATTOM & HouseCanary <span className="text-xs font-normal text-gray-400">(researched {premium_data.researched} · wired, awaiting keys)</span></h3>
+          <p className="text-xs font-medium text-purple-800 bg-purple-50 rounded-lg p-2.5 mb-3">{premium_data.verdict}</p>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-2">
+            {premium_data.providers.map(p => (
+              <div key={p.name} className="rounded-lg border border-gray-200 p-3">
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <span className="text-xs font-bold text-gray-800">{p.name}</span>
+                  <span className="text-[10px] text-gray-400">{p.entry_cost}</span>
+                </div>
+                <p className="text-xs text-gray-600 leading-relaxed mb-1.5">{p.strengths}</p>
+                <p className="text-xs font-medium text-blue-700 mb-1.5">→ {p.best_for}</p>
+                <div className="flex flex-wrap gap-1">
+                  {p.wired.map(w => <code key={w} className="text-[10px] bg-gray-100 text-gray-600 rounded px-1.5 py-0.5">{w}</code>)}
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-600 bg-gray-50 rounded-lg p-2.5">{premium_data.strategy}</p>
+        </section>
+      )}
+
+      {/* Competitive edge — why this beats the alternatives */}
+      {competitive_edge && (
+        <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+          <h3 className="text-sm font-semibold text-gray-700 mb-1.5">🥊 Competitive edge — what this app does that others don't</h3>
+          <p className="text-xs font-medium text-green-800 bg-green-50 rounded-lg p-2.5 mb-3">{competitive_edge.positioning}</p>
+          <div className="overflow-x-auto mb-3">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left font-medium px-3 py-2">Vs</th>
+                  <th className="text-left font-medium px-3 py-2">Their gap</th>
+                  <th className="text-left font-medium px-3 py-2">Our edge</th>
+                </tr>
+              </thead>
+              <tbody>
+                {competitive_edge.vs.map(c => (
+                  <tr key={c.competitor} className="border-b border-gray-50 align-top">
+                    <td className="px-3 py-2 text-xs font-semibold text-gray-800 whitespace-nowrap">{c.competitor}</td>
+                    <td className="px-3 py-2 text-xs text-gray-500">{c.their_gap}</td>
+                    <td className="px-3 py-2 text-xs text-green-700">{c.our_edge}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-1.5">
+            {competitive_edge.user_benefits.map(b => (
+              <p key={b} className="text-xs text-gray-600 bg-gray-50 rounded-lg px-2.5 py-1.5">✓ {b}</p>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Product roadmap */}
+      {product_roadmap && (
+        <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">🗺️ Roadmap — toward the most analytical new-construction investing app</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            {[['Now', product_roadmap.now, 'border-green-200 bg-green-50/40'], ['Next', product_roadmap.next, 'border-blue-200 bg-blue-50/40'], ['Later', product_roadmap.later, 'border-gray-200 bg-gray-50/60']].map(([label, items, cls]) => (
+              <div key={label} className={`rounded-lg border p-3 ${cls}`}>
+                <p className="text-xs font-bold text-gray-800 mb-1.5">{label}</p>
+                <ul className="space-y-1.5">
+                  {items.map(i => <li key={i} className="text-xs text-gray-600 leading-relaxed">• {i}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Monetization plan */}
       {monetization && (
         <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
           <h3 className="text-sm font-semibold text-gray-700 mb-1.5">💳 Monetization path (if you open it up)</h3>
           <p className="text-xs text-gray-600 mb-2">{monetization.verdict}</p>
+          {monetization.gating_status && (
+            <p className="text-xs font-medium text-purple-800 bg-purple-50 rounded-lg p-2.5 mb-2">🔒 {monetization.gating_status}</p>
+          )}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-2">
             {monetization.tiers.map(t => (
               <div key={t.tier} className="bg-gray-50 rounded-lg p-2.5">

--- a/server/.env.example
+++ b/server/.env.example
@@ -17,3 +17,12 @@ RAPIDAPI_KEY=your_rapidapi_key_here
 
 # Google Maps (optional - for map view)
 GOOGLE_MAPS_API_KEY=your_maps_key_here
+
+# Live data connectors (all optional — endpoints return {ok:false} until set)
+RENTCAST_API_KEY=        # free tier 50 calls/mo — rentcast.io/api
+HUD_API_TOKEN=           # free — huduser.gov/portal/dataset/fmr-api.html
+
+# Premium data tier (paid — see Research tab "Premium data")
+ATTOM_API_KEY=           # ~$95/mo, 30-day trial — api.developer.attomdata.com
+HC_API_KEY=              # HouseCanary Data Explorer / API
+HC_API_SECRET=

--- a/server/data/public-data-stack.md
+++ b/server/data/public-data-stack.md
@@ -91,6 +91,20 @@ GET services.arcgis.com/9Nl857LBlQVyzq54/.../Land_Development_Commercial_Project
 
 Score = policy support (place type) + entitlement activity (pending rezonings within 1 mi) + supply timing (active/pre-submittal projects within 1 mi) + infrastructure support (funded projects in design/construction nearby) − environmental constraint (floodplain/wetland intersect) ± crime context (NPA property-crime rate). The SQL join pattern is in the original research doc; implementation needs a staged PostGIS or client-side spatial pass.
 
+## Premium overlay: ATTOM + HouseCanary (paid accuracy tier)
+
+The free/official stack above is the always-on base. Two commercial providers are wired
+behind env keys (`/api/live/attom/*`, `/api/live/hc/*`) for when a deal — or a subscriber —
+justifies per-call cost:
+
+| Provider | What it adds over the free stack | Entry cost | Wired endpoints |
+|---|---|---|---|
+| **ATTOM Data** (SRC-064) | One-call diligence: assessor + owner + loan + 10-yr sales history + AVM band + foreclosure/permit events for 160M+ properties — replaces manual POLARIS→deeds→assessor hops | ~$95/mo API (30-day trial) | `attom/profile`, `attom/avm`, `attom/sales-history` (env `ATTOM_API_KEY`) |
+| **HouseCanary** (SRC-065) | Forward-looking science: monthly-refresh AVM, rental AVM, **36-month value forecasts** at block→zip granularity; 149-tool MCP server for agent workflows | Credit-based / custom | `hc/value`, `hc/rent`, `hc/forecast` (env `HC_API_KEY` + `HC_API_SECRET`) |
+
+Order of adoption: ATTOM first (diligence depth per dollar), HouseCanary when the
+Invest tab grows a forecast column. Neither replaces recorded deeds as the dispositive record.
+
 ## Limitations
 
 - Builder incentives are NOT in official data — public systems price leverage/timing, not the 5.99% buydown

--- a/server/data/sources/source-index.md
+++ b/server/data/sources/source-index.md
@@ -61,6 +61,8 @@ Mirrors the convention at [bitflipper1/Real-Estate-Knowledge/sources/source-inde
 | SRC-057 | Mungo Homes — BBB Complaints | Secondary | Better Business Bureau | — | 2026-07-05 | https://www.bbb.org/us/sc/irmo/profile/home-builders/mungo-homes-0663-12000514/complaints | Warranty validated-then-unaddressed pattern | Verified |
 | SRC-058 | Mungo Homes Homebuyers Reviews 2026 | Secondary | ComplaintsBoard | — | 2026-07-05 | https://www.complaintsboard.com/mungo-homes-b134875 | Flooring/HVAC/drainage warranty complaint themes | Verified |
 | SRC-059 | Mungo Homes Reviews | Secondary | Glassdoor | — | 2026-07-05 | https://www.glassdoor.com/Reviews/Mungo-Homes-Reviews-E1002063.htm | 3.5/5, 49 reviews, 53% recommend — weakest employee signal in set | Verified |
+| SRC-064 | ATTOM Developer Platform — API docs, product pages, AVM launch note | Secondary (vendor-published) | ATTOM Data Solutions | 2026 | 2026-07-04 | api.developer.attomdata.com/docs · attomdata.com | 160M+ properties; propertyapi/v1.0.0 base; `apikey` header; expandedprofile/attomavm/saleshistory; from ~$95/mo, 30-day trial; AI AVM launched 2026 | Corroborated (docs + Datarade + third-party reviews) |
+| SRC-065 | HouseCanary — API reference, Data Explorer, pricing, MCP announcement | Secondary (vendor-published) | HouseCanary | 2026 | 2026-07-04 | api-docs.housecanary.com · housecanary.com | v2/property/{value,rental_value,value_forecast}; key:secret basic auth; 100 items/POST; monthly-refresh AVM; 36-mo forecasts; 149-endpoint MCP server | Corroborated (docs + PyPI SDK + third-party comparisons) |
 
 ## Source status
 

--- a/server/index.js
+++ b/server/index.js
@@ -55,9 +55,11 @@ app.get('/api/listings/:id', (req, res) => {
     const row = db.prepare('SELECT * FROM listings WHERE id = ?').get(req.params.id);
     if (!row) return res.status(404).json({ error: 'Not found' });
     const history = db.prepare('SELECT price, recorded_at FROM price_history WHERE listing_id = ? ORDER BY recorded_at').all(row.id);
+    const { listingArt } = require('./src/listingArt');
+    const images = JSON.parse(row.images || '[]');
     res.json({
       ...row,
-      images: JSON.parse(row.images || '[]'),
+      images: images.length ? images : [listingArt(row)],
       features: JSON.parse(row.features || '[]'),
       price_history_detail: history,
     });
@@ -199,6 +201,23 @@ for (const [route, fn] of [['policy-map', 'policyMapNear'], ['rezonings', 'rezon
   });
 }
 app.get('/api/live/parcel/:pid', async (req, res) => res.json(await live.parcelByPid(req.params.pid)));
+
+// Premium providers. ATTOM wants address1 (street) + address2 ("City, ST" or zip);
+// HouseCanary wants address + zipcode. Both return {ok:false} until keys are set.
+for (const [route, fn] of [['attom/profile', 'attomProfile'], ['attom/avm', 'attomAvm'], ['attom/sales-history', 'attomSalesHistory']]) {
+  app.get(`/api/live/${route}`, async (req, res) => {
+    const { address1, address2 } = req.query;
+    if (!address1 || !address2) return res.status(400).json({ ok: false, reason: 'address1 and address2 required' });
+    res.json(await live[fn](address1, address2));
+  });
+}
+for (const [route, fn] of [['hc/value', 'hcValue'], ['hc/rent', 'hcRentalValue'], ['hc/forecast', 'hcValueForecast']]) {
+  app.get(`/api/live/${route}`, async (req, res) => {
+    const { address, zipcode } = req.query;
+    if (!address || !zipcode) return res.status(400).json({ ok: false, reason: 'address and zipcode required' });
+    res.json(await live[fn](address, zipcode));
+  });
+}
 
 // The corridor screen: run all official layers for a point in one shot —
 // the boom-signal test (policy ∩ entitlements ∩ pipeline) plus crime context.

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -122,6 +122,7 @@ db.exec(`
 try { db.exec('ALTER TABLE listings ADD COLUMN leaseback INTEGER DEFAULT 0'); } catch { /* exists */ }
 
 const { enrichListing } = require('./market');
+const { listingArt } = require('./listingArt');
 
 // Upsert a listing, tracking price changes
 function upsertListing(listing) {
@@ -242,13 +243,18 @@ function getListings(filters = {}) {
 
   if (filters.limit) { query += ' LIMIT ?'; params.push(parseInt(filters.limit)); }
 
-  return db.prepare(query).all(...params).map(row => ({
-    ...row,
-    images: JSON.parse(row.images || '[]'),
-    features: JSON.parse(row.features || '[]'),
-    price_history: JSON.parse(row.price_history || '[]'),
-    invest: enrichListing(row),
-  }));
+  return db.prepare(query).all(...params).map(row => {
+    const images = JSON.parse(row.images || '[]');
+    return {
+      ...row,
+      // Listings without photos get a generated render that reflects their
+      // actual attributes (see listingArt.js) — never a blank card.
+      images: images.length ? images : [listingArt(row)],
+      features: JSON.parse(row.features || '[]'),
+      price_history: JSON.parse(row.price_history || '[]'),
+      invest: enrichListing(row),
+    };
+  });
 }
 
 function getStats() {

--- a/server/src/listingArt.js
+++ b/server/src/listingArt.js
@@ -1,0 +1,142 @@
+// Listing art — deterministic SVG renders for listings that have no photo.
+//
+// Every render is generated from the listing's own attributes (beds → window
+// bays, sqft → stories, builder → brand accent, furnished → lit windows,
+// model → banner), so the image reflects THE listing, not a stock photo.
+// Renders are labeled "illustrative" and are fully self-generated: no
+// hot-linked portal/MLS photos, which matters once the app charges for access.
+//
+// Output is a data: URI, so it bakes straight into the static data.json and
+// needs no image hosting.
+
+const BRAND = {
+  'David Weekley': '#c8102e',
+  'David Weekley Homes': '#c8102e',
+  'Tri Pointe': '#1b3a5c',
+  'Tri Pointe Homes': '#1b3a5c',
+  'Ryan Homes': '#2b6cb0',
+  'Lennar': '#00539f',
+  'D.R. Horton': '#0f7a3d',
+  'DR Horton': '#0f7a3d',
+  'Mungo Homes': '#8a1f2d',
+  'Meritage Homes': '#d97706',
+  'Meritage': '#d97706',
+  'Eastwood Homes': '#b45309',
+  'Smith Douglas': '#4d7c0f',
+  'Pulte': '#7c3aed',
+  'Toll Brothers': '#334155',
+  'M/I Homes': '#0e7490',
+  'Dream Finders': '#9333ea',
+  'True Homes': '#0d9488',
+};
+
+const BRICK = ['#b0836a', '#9aa5b1', '#c9b8a3', '#8d9b8a', '#b8a08d'];
+const TRIM = '#f5f2ec';
+
+// Small deterministic hash → stable per-listing variation.
+function hash(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+
+function esc(s) {
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function listingArt(listing) {
+  const h = hash(listing.id || listing.address || 'x');
+  const accent = BRAND[listing.builder] || '#0f766e';
+  const facade = BRICK[h % BRICK.length];
+  const facade2 = BRICK[(h + 2) % BRICK.length];
+  const bays = Math.min(4, Math.max(2, listing.beds || 3));           // window bays = beds
+  const stories = (listing.sqft || 1500) > 1750 ? 3 : 2;              // 3-story over ~1750 sqft
+  const furnished = listing.is_furnished === 1 || listing.is_furnished === true;
+  const isModel = listing.is_model === 1 || listing.is_model === true;
+  const duskiness = (h >>> 4) % 3;                                     // sky variation
+
+  const skies = [
+    ['#dbeafe', '#eff6ff'], // day
+    ['#bfdbfe', '#e0f2fe'], // bright
+    ['#fde68a', '#dbeafe'], // golden hour
+  ];
+  const [skyTop, skyBot] = skies[furnished ? 2 : duskiness];          // furnished = warm golden light
+
+  const W = 400, H = 220, ground = 182;
+  const bW = 190, bX = (W - bW) / 2;
+  const floorH = 42, roofH = 16;
+  const bTop = ground - stories * floorH - roofH;
+
+  let el = '';
+  // sky + ground
+  el += `<defs><linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="${skyTop}"/><stop offset="1" stop-color="${skyBot}"/></linearGradient></defs>`;
+  el += `<rect width="${W}" height="${H}" fill="url(#sky)"/>`;
+  el += `<rect y="${ground}" width="${W}" height="${H - ground}" fill="#8fae87"/>`;
+  el += `<rect y="${ground}" width="${W}" height="4" fill="#7a9a72"/>`;
+
+  // background rooflines (the rest of the townhome row)
+  el += `<rect x="${bX - 60}" y="${bTop + 26}" width="70" height="${ground - bTop - 26}" fill="${facade2}" opacity="0.55"/>`;
+  el += `<rect x="${bX + bW - 10}" y="${bTop + 34}" width="70" height="${ground - bTop - 34}" fill="${facade2}" opacity="0.55"/>`;
+
+  // main unit
+  el += `<rect x="${bX}" y="${bTop + roofH}" width="${bW}" height="${stories * floorH}" fill="${facade}"/>`;
+  // roof (gable or flat-parapet by hash)
+  if (h % 2 === 0) {
+    el += `<polygon points="${bX - 8},${bTop + roofH} ${bX + bW / 2},${bTop - 6} ${bX + bW + 8},${bTop + roofH}" fill="#4b5563"/>`;
+  } else {
+    el += `<rect x="${bX - 6}" y="${bTop + 4}" width="${bW + 12}" height="${roofH}" fill="#4b5563"/>`;
+  }
+
+  // window bays per story (top stories) + entry level
+  const gap = 12, bayW = (bW - gap * (bays + 1)) / bays;
+  const winFill = furnished ? '#fbbf24' : '#bfdbfe';
+  const winStroke = furnished ? '#d97706' : '#64748b';
+  for (let s = 0; s < stories - 1; s++) {
+    const wy = bTop + roofH + 8 + s * floorH;
+    for (let b = 0; b < bays; b++) {
+      const wx = bX + gap + b * (bayW + gap);
+      el += `<rect x="${wx}" y="${wy}" width="${bayW}" height="${floorH - 16}" rx="2" fill="${winFill}" stroke="${winStroke}" stroke-width="1.5"/>`;
+      el += `<line x1="${wx + bayW / 2}" y1="${wy}" x2="${wx + bayW / 2}" y2="${wy + floorH - 16}" stroke="${winStroke}" stroke-width="1"/>`;
+    }
+  }
+  // entry level: door (brand color) with sidelight + garage
+  const ey = ground - floorH + 6;
+  const doorW = 22, doorX = bX + gap;
+  el += `<rect x="${doorX - 3}" y="${ey - 3}" width="${doorW + 6}" height="${floorH - 3}" fill="${TRIM}"/>`;
+  el += `<rect x="${doorX}" y="${ey}" width="${doorW}" height="${floorH - 6}" rx="2" fill="${accent}"/>`;
+  el += `<circle cx="${doorX + doorW - 5}" cy="${ey + (floorH - 6) / 2}" r="2" fill="${TRIM}"/>`;
+  const garX = doorX + doorW + 16, garW = bX + bW - gap - garX;
+  el += `<rect x="${garX}" y="${ey + 2}" width="${garW}" height="${floorH - 8}" rx="3" fill="#6b7280"/>`;
+  el += `<g stroke="#9ca3af" stroke-width="1.5">` +
+    [1, 2, 3].map(i => `<line x1="${garX + 2}" y1="${ey + 2 + i * (floorH - 8) / 4}" x2="${garX + garW - 2}" y2="${ey + 2 + i * (floorH - 8) / 4}"/>`).join('') + `</g>`;
+  // trim band between floors
+  for (let s = 1; s < stories; s++) {
+    el += `<rect x="${bX}" y="${bTop + roofH + s * floorH - 2}" width="${bW}" height="3" fill="${TRIM}" opacity="0.8"/>`;
+  }
+
+  // landscaping — positions vary by hash
+  const t1 = 30 + (h % 40), t2 = W - 60 - ((h >>> 8) % 40);
+  for (const tx of [t1, t2]) {
+    el += `<rect x="${tx - 2}" y="${ground - 26}" width="5" height="26" fill="#7c5a3c"/>`;
+    el += `<circle cx="${tx}" cy="${ground - 34}" r="16" fill="#5f8f56"/><circle cx="${tx + 9}" cy="${ground - 26}" r="11" fill="#6da063"/>`;
+  }
+  el += `<rect x="${bX + 8}" y="${ground - 3}" width="${bW - 16}" height="6" rx="3" fill="#94a688"/>`;
+
+  // model banner
+  if (isModel) {
+    el += `<rect x="${bX + bW - 14}" y="${bTop + roofH + 6}" width="4" height="34" fill="#4b5563"/>`;
+    el += `<path d="M ${bX + bW - 10} ${bTop + roofH + 6} h 44 l -8 7 8 7 h -44 z" fill="${accent}"/>`;
+    el += `<text x="${bX + bW + 11}" y="${bTop + roofH + 16}" font-family="Arial,sans-serif" font-size="8" font-weight="bold" fill="#fff" text-anchor="middle">MODEL</text>`;
+  }
+
+  // caption bar: honest label + what the render encodes
+  const cap = [listing.community || listing.city, listing.builder].filter(Boolean).join(' · ');
+  el += `<rect y="${H - 22}" width="${W}" height="22" fill="#0f172a" opacity="0.78"/>`;
+  el += `<text x="10" y="${H - 8}" font-family="Arial,sans-serif" font-size="10" fill="#e2e8f0">${esc(cap).slice(0, 52)}</text>`;
+  el += `<text x="${W - 10}" y="${H - 8}" font-family="Arial,sans-serif" font-size="9" fill="#94a3b8" text-anchor="end">Illustrative render</text>`;
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">${el}</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+module.exports = { listingArt };

--- a/server/src/liveapis.js
+++ b/server/src/liveapis.js
@@ -131,4 +131,68 @@ async function parcelByPid(pid) {
   return { ok: true, source: 'Parcel Zoning Lookup', parcel: r.data?.features?.[0]?.attributes || null };
 }
 
-module.exports = { censusMecklenburg, permitsNear, rentEstimate, hudFmr, policyMapNear, rezoningsNear, crimeNear, pipelineNear, parcelByPid };
+// ---- Premium data providers (paid keys; both degrade gracefully). ----
+
+// ATTOM Data — 160M+ US properties: expanded profile, AVM, sales history,
+// all-events. Header auth: `apikey`. Base plan ~$95/mo (30-day trial available).
+// Key: ATTOM_API_KEY (api.developer.attomdata.com).
+const ATTOM_BASE = 'https://api.gateway.attomdata.com/propertyapi/v1.0.0';
+
+async function attomCall(resource, params) {
+  if (!process.env.ATTOM_API_KEY) return { ok: false, reason: 'ATTOM_API_KEY not set (trial key: api.developer.attomdata.com)' };
+  return safeGet(`${ATTOM_BASE}/${resource}`, {
+    params, headers: { apikey: process.env.ATTOM_API_KEY, Accept: 'application/json' },
+  });
+}
+
+// Assessor + owner + latest loan/transaction for an address.
+// address1 = street, address2 = "City, ST" or zip.
+async function attomProfile(address1, address2) {
+  const r = await attomCall('property/expandedprofile', { address1, address2 });
+  if (!r.ok) return r;
+  return { ok: true, source: 'ATTOM expanded profile', property: r.data?.property?.[0] || null };
+}
+
+// ATTOM AVM — market-value estimate with high/low band.
+async function attomAvm(address1, address2) {
+  const r = await attomCall('attomavm/detail', { address1, address2 });
+  if (!r.ok) return r;
+  const p = r.data?.property?.[0];
+  return { ok: true, source: 'ATTOM AVM', avm: p?.avm?.amount || null, address: p?.address || null };
+}
+
+// Recorded sales history (10 yrs) — the resale-velocity check for a community.
+async function attomSalesHistory(address1, address2) {
+  const r = await attomCall('saleshistory/detail', { address1, address2 });
+  if (!r.ok) return r;
+  const p = r.data?.property?.[0];
+  return { ok: true, source: 'ATTOM sales history', history: p?.salehistory || [], address: p?.address || null };
+}
+
+// HouseCanary — AVM + rental AVM + 36-month value forecasts, block→state
+// granularity. Basic auth key:secret on api.housecanary.com/v2.
+// Keys: HC_API_KEY + HC_API_SECRET (housecanary.com Data Explorer / API).
+async function hcCall(target, address, zipcode) {
+  if (!process.env.HC_API_KEY || !process.env.HC_API_SECRET) {
+    return { ok: false, reason: 'HC_API_KEY / HC_API_SECRET not set (housecanary.com/products/data-explorer)' };
+  }
+  return safeGet(`https://api.housecanary.com/v2/property/${target}`, {
+    params: { address, zipcode },
+    auth: { username: process.env.HC_API_KEY, password: process.env.HC_API_SECRET },
+  });
+}
+
+const hcResult = (r, target) => {
+  if (!r.ok) return r;
+  const item = Array.isArray(r.data) ? r.data[0] : r.data;
+  return { ok: true, source: `HouseCanary ${target}`, result: item?.[`property/${target}`]?.result ?? item };
+};
+
+async function hcValue(address, zipcode) { return hcResult(await hcCall('value', address, zipcode), 'value'); }
+async function hcRentalValue(address, zipcode) { return hcResult(await hcCall('rental_value', address, zipcode), 'rental_value'); }
+async function hcValueForecast(address, zipcode) { return hcResult(await hcCall('value_forecast', address, zipcode), 'value_forecast'); }
+
+module.exports = {
+  censusMecklenburg, permitsNear, rentEstimate, hudFmr, policyMapNear, rezoningsNear, crimeNear, pipelineNear, parcelByPid,
+  attomProfile, attomAvm, attomSalesHistory, hcValue, hcRentalValue, hcValueForecast,
+};


### PR DESCRIPTION
Feature work rebuilt on top of the privacy-hardened history (post PR #8, post history purge).

## What's included

- **Listing renders for every card** — `server/src/listingArt.js` generates deterministic SVG illustrations from each listing's own attributes (beds → window bays, sqft → stories, builder brand color, furnished → lit windows, model banner). Honest "Illustrative render" label; no hot-linked portal photos, zero licensing exposure.
- **ATTOM + HouseCanary connectors** — `/api/live/attom/{profile|avm|sales-history}` and `/api/live/hc/{value|rent|forecast}`, gated behind env keys with graceful degradation. Vendor source rows SRC-064/065 and a premium-overlay section in the public data stack doc.
- **Deal Room, privacy-safe** — static builds keep the disabled stub from #8; full-stack mode restores the underwriting calculator with the benchmark loaded at runtime from the gitignored private research file over the loopback-gated API. No personal numbers in the repo.
- **Research tab panels** — premium data tier, competitive edge, and Now/Next/Later roadmap; render only when the private research API supplies data (hidden on public builds).
- `.env.example` connector key slots re-added on the scrubbed template; dangling README screenshot links from the history purge removed.

## Verification

- Server privacy tests pass (4/4); CI runs them as a deploy gate
- Static export produces public-only snapshot (55 listings, no private sources)
- Static build clean; personal-marker scan of tree and snapshot: zero hits
- Build job on this branch is green (deploy job failure is the expected Pages environment restriction to master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_