### PR TITLE
Bump better-sqlite3 to ^12 for Node 22/24 compatibility

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.7.2",
-        "better-sqlite3": "^9.6.0",
+        "better-sqlite3": "^12.2.0",
         "cheerio": "^1.0.0-rc.12",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -138,14 +138,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/binary-extensions": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
-    "better-sqlite3": "^9.6.0",
+    "better-sqlite3": "^12.2.0",
     "cheerio": "^1.0.0-rc.12",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
`better-sqlite3@9.6.0` has no prebuilt binary for Node 24, so `npm install` falls back to compiling from source — which fails against Node 24's C++20-requiring V8 headers (`error: "C++20 or later required."`). This blocks local dev on current Node versions.

Bumping to `^12.2.0` ships prebuilt binaries for Node 20/22/24 (no compiler needed) and stays compatible with the Node 20 CI/Pages build.

Verified in-sandbox: module loads, DB reads 80 listings, privacy test suite passes 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_