### PR TITLE
Deal document vault: private uploads + Google Drive index per deal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ server/data/model-homes.json
 server/data/research.json
 .DS_Store
 *.log
+server/data/deal-files/

--- a/client/src/components/DealDocuments.jsx
+++ b/client/src/components/DealDocuments.jsx
@@ -1,0 +1,156 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { FolderOpen, Upload, FileText, Image as ImageIcon, Trash2, ExternalLink, Loader2, Mic, Mail, File } from 'lucide-react';
+
+// Private per-deal document vault. Uploads go to the loopback-gated server
+// (gitignored server/data/deal-files/<slug>/); the Drive section renders the
+// manifest.json index so documents that live in Google Drive are one click
+// away. Only mounted in full-stack mode — never in the public static build.
+
+const fmtSize = b => b == null ? '' : b > 1048576 ? `${(b / 1048576).toFixed(1)} MB` : `${Math.max(1, Math.round(b / 1024))} KB`;
+const isImage = name => /\.(png|jpe?g|gif|webp|heic)$/i.test(name);
+
+const TYPE_ICON = { pdf: FileText, gdoc: FileText, docx: FileText, txt: FileText, eml: Mail, audio: Mic };
+
+export default function DealDocuments({ slug, title }) {
+  const [data, setData] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/deals/${slug}/files`);
+      if (!r.ok) throw new Error((await r.json()).error || `HTTP ${r.status}`);
+      setData(await r.json());
+      setErr('');
+    } catch (e) {
+      setErr(`Documents unavailable: ${e.message} — is ALLOW_PRIVATE_LOCAL=true set in server/.env?`);
+    }
+  }, [slug]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const uploadFiles = useCallback(async (fileList) => {
+    if (!fileList?.length) return;
+    setBusy(true);
+    try {
+      const form = new FormData();
+      for (const f of fileList) form.append('files', f);
+      const r = await fetch(`/api/deals/${slug}/files`, { method: 'POST', body: form });
+      if (!r.ok) throw new Error((await r.json()).error || `Upload failed (HTTP ${r.status})`);
+      await load();
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setBusy(false);
+    }
+  }, [slug, load]);
+
+  async function remove(name) {
+    if (!window.confirm(`Delete ${name}? (Removes the local copy only — Drive is untouched.)`)) return;
+    await fetch(`/api/deals/${slug}/files/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    await load();
+  }
+
+  const uploads = data?.uploads || [];
+  const drive = data?.drive;
+
+  return (
+    <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <FolderOpen className="w-4 h-4 text-blue-600" />
+        <h3 className="text-sm font-semibold text-gray-800">Documents — {title || slug}</h3>
+        {drive?.drive_folder?.url && (
+          <a href={drive.drive_folder.url} target="_blank" rel="noopener noreferrer"
+            className="ml-auto text-xs text-blue-600 hover:underline flex items-center gap-1">
+            Open Drive folder <ExternalLink className="w-3 h-3" />
+          </a>
+        )}
+      </div>
+
+      {err && <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2.5">{err}</p>}
+
+      {/* Upload zone */}
+      <div
+        onDragOver={e => { e.preventDefault(); setDragging(true); }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={e => { e.preventDefault(); setDragging(false); uploadFiles(e.dataTransfer.files); }}
+        onClick={() => inputRef.current?.click()}
+        className={`border-2 border-dashed rounded-xl p-5 text-center cursor-pointer transition ${
+          dragging ? 'border-blue-400 bg-blue-50' : 'border-gray-200 hover:border-blue-300 hover:bg-gray-50'
+        }`}
+      >
+        <input ref={inputRef} type="file" multiple className="hidden" onChange={e => { uploadFiles(e.target.files); e.target.value = ''; }} />
+        {busy
+          ? <p className="text-sm text-gray-500 flex items-center justify-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Uploading…</p>
+          : <p className="text-sm text-gray-500 flex items-center justify-center gap-2">
+              <Upload className="w-4 h-4" /> Drop photos or documents here, or click to choose (stored locally, never in Git)
+            </p>}
+      </div>
+
+      {/* Local uploads */}
+      {uploads.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-gray-500 mb-2">Uploaded locally ({uploads.length})</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+            {uploads.map(f => (
+              <div key={f.name} className="group relative rounded-lg border border-gray-200 overflow-hidden">
+                <a href={`/api/deals/${slug}/files/${encodeURIComponent(f.name)}`} target="_blank" rel="noopener noreferrer" className="block">
+                  {isImage(f.name) ? (
+                    <img src={`/api/deals/${slug}/files/${encodeURIComponent(f.name)}`} alt={f.name} className="h-24 w-full object-cover" />
+                  ) : (
+                    <div className="h-24 flex items-center justify-center bg-gray-50"><FileText className="w-8 h-8 text-gray-300" /></div>
+                  )}
+                  <div className="px-2 py-1.5">
+                    <p className="text-[11px] font-medium text-gray-700 truncate">{f.name}</p>
+                    <p className="text-[10px] text-gray-400">{fmtSize(f.size)}</p>
+                  </div>
+                </a>
+                <button onClick={() => remove(f.name)} title="Delete local copy"
+                  className="absolute top-1 right-1 p-1 rounded bg-white/90 shadow opacity-0 group-hover:opacity-100 transition">
+                  <Trash2 className="w-3.5 h-3.5 text-red-500" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Drive index */}
+      {drive?.folders?.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-gray-500 mb-2">
+            In Google Drive ({drive.folders.reduce((n, f) => n + f.files.length, 0)} documents · synced {drive.synced_at})
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {drive.folders.map(folder => (
+              <div key={folder.name} className="rounded-lg border border-gray-200 p-3">
+                <a href={folder.url} target="_blank" rel="noopener noreferrer"
+                  className="text-xs font-bold text-gray-800 hover:text-blue-700 flex items-center gap-1.5 mb-1.5">
+                  <FolderOpen className="w-3.5 h-3.5 text-amber-500" /> {folder.name}
+                  <span className="font-normal text-gray-400">({folder.files.length})</span>
+                </a>
+                <ul className="space-y-1">
+                  {folder.files.map(f => {
+                    const Icon = TYPE_ICON[f.type] || File;
+                    return (
+                      <li key={f.url}>
+                        <a href={f.url} target="_blank" rel="noopener noreferrer"
+                          className="text-xs text-gray-600 hover:text-blue-700 hover:underline flex items-start gap-1.5">
+                          <Icon className="w-3 h-3 mt-0.5 shrink-0 text-gray-400" />
+                          <span className="truncate">{f.title}</span>
+                          {f.size && <span className="ml-auto shrink-0 text-[10px] text-gray-400">{fmtSize(f.size)}</span>}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/DealRoom.jsx
+++ b/client/src/components/DealRoom.jsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { Lock, Unlock, ShieldAlert, Calculator } from 'lucide-react';
 import { IS_STATIC } from '../staticData';
+import DealDocuments from './DealDocuments';
 
 // The public static site never ships underwriting or benchmark data — the
 // private tier requires the local server (research.json is gitignored and its
@@ -125,6 +126,9 @@ export default function DealRoom({ market, research }) {
           )}
         </section>
       </div>
+
+      {/* Per-deal document vault: local uploads + Drive index (private tier) */}
+      <DealDocuments slug="3912-craig-ave" title={yd?.property?.split('—')[0]?.trim() || '3912 Craig Ave'} />
     </div>
   );
 }

--- a/server/data/README.md
+++ b/server/data/README.md
@@ -9,6 +9,7 @@ The following runtime files are private and gitignored:
 - `model-homes.json`
 - `research.json`
 - `*.db`, `*.db-shm`, and `*.db-wal`
+- `deal-files/` (per-deal contracts, photos, closing documents, Drive manifests)
 
 Do not commit contracts, payment records, inbox exports, negotiation notes,
 personal contact details, tracked places, or buyer-specific underwriting.

--- a/server/index.js
+++ b/server/index.js
@@ -231,6 +231,49 @@ app.get('/api/live/corridor', async (req, res) => {
   res.json({ ok: true, boom_signal: boom, note: boom ? 'Policy ∩ entitlements ∩ pipeline all present — verify infrastructure (CAP) + flood before pursuing' : 'Not all three boom conditions present (or a layer was unreachable)', policy, rezonings, crime, pipeline });
 });
 
+// --- Deal document vault (private: contracts, photos, closing docs) ---
+// Files live in gitignored server/data/deal-files/<slug>/; a manifest.json
+// there indexes the deal's Google Drive folder for link-outs.
+const multer = require('multer');
+const dealFiles = require('./src/dealFiles');
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, cb) => {
+      try { cb(null, dealFiles.ensureDealDir(req.params.slug)); } catch (e) { cb(e); }
+    },
+    filename: (req, file, cb) => {
+      try { cb(null, dealFiles.safeName(file.originalname)); } catch (e) { cb(e); }
+    },
+  }),
+  limits: { fileSize: 50 * 1024 * 1024, files: 20 },
+});
+
+app.get('/api/deals', privateLocalOnly, (req, res) => {
+  try { res.json({ deals: dealFiles.listDeals() }); } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+app.get('/api/deals/:slug/files', privateLocalOnly, (req, res) => {
+  try { res.json(dealFiles.listDealFiles(req.params.slug)); } catch (err) { res.status(400).json({ error: err.message }); }
+});
+
+app.post('/api/deals/:slug/files', privateLocalOnly, upload.array('files'), (req, res) => {
+  res.json({ uploaded: (req.files || []).map(f => ({ name: f.filename, size: f.size })) });
+});
+
+app.get('/api/deals/:slug/files/:name', privateLocalOnly, (req, res) => {
+  try {
+    const p = dealFiles.filePath(req.params.slug, req.params.name);
+    if (!p) return res.status(404).json({ error: 'Not found' });
+    res.sendFile(p);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.delete('/api/deals/:slug/files/:name', privateLocalOnly, (req, res) => {
+  try { res.json({ deleted: dealFiles.deleteFile(req.params.slug, req.params.name) }); } catch (err) { res.status(400).json({ error: err.message }); }
+});
+
 // --- Tracked places (personal tour tracker) ---
 app.get('/api/tracked', privateLocalOnly, (req, res) => {
   try {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "multer": "^2.2.0",
         "node-cron": "^3.0.3",
         "user-agents": "^1.1.228"
       },
@@ -82,6 +83,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -276,6 +283,23 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -397,6 +421,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -1344,6 +1383,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1966,6 +2024,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2081,6 +2147,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "multer": "^2.2.0",
     "node-cron": "^3.0.3",
     "user-agents": "^1.1.228"
   },

--- a/server/src/dealFiles.js
+++ b/server/src/dealFiles.js
@@ -1,0 +1,79 @@
+// Per-deal document vault — uploads and a Drive index, both private.
+//
+// Files live under server/data/deal-files/<deal-slug>/ (gitignored, never in
+// the public snapshot). An optional manifest.json alongside the uploads
+// indexes the deal's Google Drive folder so the UI can link out to documents
+// that stay in Drive. Routes that use this module must sit behind
+// privateLocalOnly.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', 'data', 'deal-files');
+const MANIFEST = 'manifest.json';
+
+// Slugs and filenames are used to build filesystem paths — keep both to a
+// conservative charset so traversal ("../") is impossible by construction.
+function safeSlug(slug) {
+  const s = String(slug || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
+  if (!s) throw new Error('Invalid deal slug');
+  return s;
+}
+
+function safeName(name) {
+  const n = path.basename(String(name || '')).replace(/[^\w.\- ()]/g, '_').trim();
+  if (!n || n === MANIFEST) throw new Error('Invalid file name');
+  return n;
+}
+
+function dealDir(slug) {
+  return path.join(ROOT, safeSlug(slug));
+}
+
+function ensureDealDir(slug) {
+  const dir = dealDir(slug);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function listDeals() {
+  if (!fs.existsSync(ROOT)) return [];
+  return fs.readdirSync(ROOT, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+}
+
+function listDealFiles(slug) {
+  const dir = dealDir(slug);
+  let uploads = [];
+  let drive = null;
+  if (fs.existsSync(dir)) {
+    uploads = fs.readdirSync(dir)
+      .filter(f => f !== MANIFEST && !f.startsWith('.'))
+      .map(f => {
+        const st = fs.statSync(path.join(dir, f));
+        return { name: f, size: st.size, modified: st.mtime.toISOString() };
+      })
+      .sort((a, b) => b.modified.localeCompare(a.modified));
+    const mPath = path.join(dir, MANIFEST);
+    if (fs.existsSync(mPath)) {
+      try { drive = JSON.parse(fs.readFileSync(mPath, 'utf8')); } catch { drive = null; }
+    }
+  }
+  return { slug: safeSlug(slug), uploads, drive };
+}
+
+function filePath(slug, name) {
+  const p = path.join(dealDir(slug), safeName(name));
+  if (!fs.existsSync(p)) return null;
+  return p;
+}
+
+function deleteFile(slug, name) {
+  const p = filePath(slug, name);
+  if (!p) return false;
+  fs.unlinkSync(p);
+  return true;
+}
+
+module.exports = { ROOT, safeSlug, safeName, ensureDealDir, listDeals, listDealFiles, filePath, deleteFile };


### PR DESCRIPTION
Adds a per-deal document vault to the Deal Room (private tier), first deal: 3912 Craig Ave.

## What's included
- **Server**: `dealFiles.js` module storing files under gitignored `server/data/deal-files/<slug>/`; slugs and filenames constrained to a safe charset so path traversal is impossible by construction. Loopback-gated routes (`privateLocalOnly`): list, multipart upload (multer, 50MB × 20 files), serve, delete.
- **Drive index**: an optional `manifest.json` per deal indexes the deal's Google Drive folder; the UI renders it as grouped folders with one-click links, so Drive remains the source of truth for existing documents while photos/new docs can be dropped straight into the app.
- **Client**: `DealDocuments` component in the Deal Room — drag-drop upload zone, image thumbnails, Drive folder index. Full-stack mode only; never mounted in the public static build.
- No private data in this diff: the deal-files directory (including the manifest) is gitignored and documented in `server/data/README.md`.

## Verification
- Upload → fetch → delete round-trip works; traversal attempt returns 404
- `ALLOW_PRIVATE_LOCAL=false` disables all deal routes (404)
- Privacy tests 4/4; client production build passes
- UI verified in-browser with the seeded 32-document Drive manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_