### PR TITLE
Deal Room: one-click ATTOM + HouseCanary diligence for any address

### DIFF
--- a/client/src/components/DealDiligence.jsx
+++ b/client/src/components/DealDiligence.jsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import { Search, Loader2, Building2, User, TrendingUp, DollarSign, Home, AlertCircle, ChevronDown, ChevronRight } from 'lucide-react';
+
+// Private diligence panel — one address, two providers, in parallel:
+// ATTOM (AVM + owner/records + sales history) and HouseCanary (value + rent +
+// 3-yr forecast). Loopback-gated route; Deal Room (private tier) only.
+
+const money = n => {
+  const v = typeof n === 'object' && n ? (n.value ?? n.amount ?? n.price) : n;
+  return (v || v === 0) && !isNaN(v) ? `$${Math.round(v).toLocaleString()}` : null;
+};
+
+// A block that renders its provider's data or the {ok:false} reason it gave.
+function Provider({ title, icon: Icon, r, children }) {
+  if (!r) return null;
+  return (
+    <div className="rounded-xl border border-gray-200 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className="w-4 h-4 text-blue-600" />
+        <h4 className="text-sm font-semibold text-gray-800">{title}</h4>
+      </div>
+      {r.ok ? children : (
+        <p className="text-xs text-amber-700 bg-amber-50 rounded-lg px-2.5 py-1.5 flex items-start gap-1.5">
+          <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" /> {r.reason || 'No data returned'}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Collapsible raw JSON — the escape hatch so unusual provider shapes are always
+// visible even before we tune field-by-field formatting.
+function Raw({ data }) {
+  const [open, setOpen] = useState(false);
+  if (!data) return null;
+  return (
+    <div className="mt-2">
+      <button onClick={() => setOpen(o => !o)} className="text-[11px] text-gray-400 hover:text-gray-600 flex items-center gap-1">
+        {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />} raw data
+      </button>
+      {open && <pre className="mt-1 text-[10px] bg-gray-50 rounded-lg p-2 overflow-x-auto max-h-56 text-gray-600">{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default function DealDiligence() {
+  const [f, setF] = useState({ address1: '', address2: 'Charlotte, NC', zipcode: '' });
+  const [data, setData] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  async function run() {
+    if (!f.address1.trim()) { setErr('Enter a street address'); return; }
+    setBusy(true); setErr(''); setData(null);
+    try {
+      const q = new URLSearchParams({ address1: f.address1.trim(), address2: f.address2.trim(), zipcode: f.zipcode.trim() });
+      const r = await fetch(`/api/live/diligence?${q}`);
+      const j = await r.json();
+      if (!r.ok || !j.ok) throw new Error(j.reason || j.error || `HTTP ${r.status}`);
+      setData(j);
+    } catch (e) {
+      setErr(`${e.message}${e.message.includes('disabled') ? ' — set ALLOW_PRIVATE_LOCAL=true in server/.env' : ''}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const inp = (key, ph, w) => (
+    <input value={f[key]} onChange={e => setF({ ...f, [key]: e.target.value })} placeholder={ph}
+      onKeyDown={e => e.key === 'Enter' && run()}
+      className={`${w} px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500`} />
+  );
+
+  const attom = data?.attom, hc = data?.housecanary;
+  const owner = attom?.profile?.ok ? attom.profile.property : null;
+
+  return (
+    <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 space-y-4">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Search className="w-4 h-4 text-blue-600" />
+          <h3 className="text-sm font-semibold text-gray-800">Property diligence — any address</h3>
+        </div>
+        <p className="text-xs text-gray-500">ATTOM records + AVM and HouseCanary value/rent/forecast for any US address — a listing, a resale, or an off-market home you want to research. Owner data is public record; keep it private.</p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center">
+        {inp('address1', 'Street address', 'flex-1 min-w-[180px]')}
+        {inp('address2', 'City, ST', 'w-32')}
+        {inp('zipcode', 'ZIP', 'w-20')}
+        <button onClick={run} disabled={busy}
+          className="px-4 py-1.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 flex items-center gap-1.5">
+          {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />} Run diligence
+        </button>
+      </div>
+
+      {err && <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2.5">{err}</p>}
+
+      {data && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <Provider title="ATTOM — value estimate (AVM)" icon={DollarSign} r={attom.avm}>
+            <p className="text-2xl font-bold text-gray-900">{money(attom.avm.avm) || '—'}</p>
+            <p className="text-xs text-gray-400">Independent automated valuation</p>
+            <Raw data={attom.avm.avm} />
+          </Provider>
+
+          <Provider title="ATTOM — owner & records" icon={User} r={attom.profile}>
+            <dl className="text-xs space-y-0.5">
+              {owner?.owner && <div className="flex justify-between"><dt className="text-gray-500">Owner</dt><dd className="font-medium text-right">{owner.owner?.owner1?.lastname || owner.owner?.description || '—'}</dd></div>}
+              {owner?.summary?.propclass && <div className="flex justify-between"><dt className="text-gray-500">Type</dt><dd className="text-right">{owner.summary.propclass}</dd></div>}
+              {money(owner?.assessment?.market?.mktttlvalue) && <div className="flex justify-between"><dt className="text-gray-500">Assessed value</dt><dd className="font-medium text-right">{money(owner.assessment.market.mktttlvalue)}</dd></div>}
+              {money(owner?.sale?.amount?.saleamt) && <div className="flex justify-between"><dt className="text-gray-500">Last sale</dt><dd className="font-medium text-right">{money(owner.sale.amount.saleamt)}</dd></div>}
+            </dl>
+            <Raw data={owner} />
+          </Provider>
+
+          <Provider title="ATTOM — sales history" icon={Building2} r={attom.sales}>
+            {Array.isArray(attom.sales.history) && attom.sales.history.length ? (
+              <ul className="text-xs space-y-1">
+                {attom.sales.history.slice(0, 6).map((s, i) => (
+                  <li key={i} className="flex justify-between">
+                    <span className="text-gray-500">{s.saleTransDate || s.amount?.salerecdate || s.saleSearchDate || '—'}</span>
+                    <span className="font-medium">{money(s.amount?.saleamt) || '—'}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : <p className="text-xs text-gray-400">No recorded sales returned.</p>}
+            <Raw data={attom.sales.history} />
+          </Provider>
+
+          <Provider title="HouseCanary — value" icon={DollarSign} r={hc.value}>
+            <p className="text-2xl font-bold text-gray-900">{money(hc.value.result?.value?.value ?? hc.value.result?.value) || '—'}</p>
+            <p className="text-xs text-gray-400">HouseCanary AVM</p>
+            <Raw data={hc.value.result} />
+          </Provider>
+
+          <Provider title="HouseCanary — rent estimate" icon={Home} r={hc.rent}>
+            <p className="text-2xl font-bold text-gray-900">{money(hc.rent.result?.value?.value ?? hc.rent.result?.value) || '—'}<span className="text-sm font-normal text-gray-400">/mo</span></p>
+            <p className="text-xs text-gray-400">Rental AVM — ground-truth your leaseback yield</p>
+            <Raw data={hc.rent.result} />
+          </Provider>
+
+          <Provider title="HouseCanary — 3-year forecast" icon={TrendingUp} r={hc.forecast}>
+            <p className="text-xs text-gray-500 mb-1">Projected value path (36 months)</p>
+            <Raw data={hc.forecast.result} />
+          </Provider>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/DealRoom.jsx
+++ b/client/src/components/DealRoom.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { Lock, Unlock, ShieldAlert, Calculator } from 'lucide-react';
 import { IS_STATIC } from '../staticData';
 import DealDocuments from './DealDocuments';
+import DealDiligence from './DealDiligence';
 
 // The public static site never ships underwriting or benchmark data — the
 // private tier requires the local server (research.json is gitignored and its
@@ -128,6 +129,9 @@ export default function DealRoom({ market, research }) {
       </div>
 
       {/* Per-deal document vault: local uploads + Drive index (private tier) */}
+      {/* Live property diligence: ATTOM + HouseCanary for any address (paid keys) */}
+      <DealDiligence />
+
       <DealDocuments slug="3912-craig-ave" title={yd?.property?.split('—')[0]?.trim() || '3912 Craig Ave'} />
     </div>
   );

--- a/server/index.js
+++ b/server/index.js
@@ -202,22 +202,44 @@ for (const [route, fn] of [['policy-map', 'policyMapNear'], ['rezonings', 'rezon
 }
 app.get('/api/live/parcel/:pid', async (req, res) => res.json(await live.parcelByPid(req.params.pid)));
 
-// Premium providers. ATTOM wants address1 (street) + address2 ("City, ST" or zip);
+// Premium providers — loopback-gated: they consume paid API keys and ATTOM
+// returns owner PII, so these are private-tier only, never on the public site.
+// ATTOM wants address1 (street) + address2 ("City, ST" or zip);
 // HouseCanary wants address + zipcode. Both return {ok:false} until keys are set.
 for (const [route, fn] of [['attom/profile', 'attomProfile'], ['attom/avm', 'attomAvm'], ['attom/sales-history', 'attomSalesHistory']]) {
-  app.get(`/api/live/${route}`, async (req, res) => {
+  app.get(`/api/live/${route}`, privateLocalOnly, async (req, res) => {
     const { address1, address2 } = req.query;
     if (!address1 || !address2) return res.status(400).json({ ok: false, reason: 'address1 and address2 required' });
     res.json(await live[fn](address1, address2));
   });
 }
 for (const [route, fn] of [['hc/value', 'hcValue'], ['hc/rent', 'hcRentalValue'], ['hc/forecast', 'hcValueForecast']]) {
-  app.get(`/api/live/${route}`, async (req, res) => {
+  app.get(`/api/live/${route}`, privateLocalOnly, async (req, res) => {
     const { address, zipcode } = req.query;
     if (!address || !zipcode) return res.status(400).json({ ok: false, reason: 'address and zipcode required' });
     res.json(await live[fn](address, zipcode));
   });
 }
+
+// One-shot diligence: ATTOM (AVM + owner/loan + sales history) and HouseCanary
+// (value + rent + 3-yr forecast) for a single address, in parallel. address1 =
+// street, address2 = "City, ST", zipcode = 5-digit. Each provider degrades
+// independently, so a missing HC secret still returns the ATTOM half.
+app.get('/api/live/diligence', privateLocalOnly, async (req, res) => {
+  const { address1, address2, zipcode } = req.query;
+  if (!address1 || !address2) return res.status(400).json({ ok: false, reason: 'address1 and address2 required' });
+  const addr = `${address1}, ${address2}`;
+  const zip = zipcode || (address2.match(/\b(\d{5})\b/) || [])[1] || '';
+  const [avm, profile, sales, hcValue, hcRent, hcForecast] = await Promise.all([
+    live.attomAvm(address1, address2),
+    live.attomProfile(address1, address2),
+    live.attomSalesHistory(address1, address2),
+    zip ? live.hcValue(addr, zip) : { ok: false, reason: 'zipcode required for HouseCanary' },
+    zip ? live.hcRentalValue(addr, zip) : { ok: false, reason: 'zipcode required for HouseCanary' },
+    zip ? live.hcValueForecast(addr, zip) : { ok: false, reason: 'zipcode required for HouseCanary' },
+  ]);
+  res.json({ ok: true, address: addr, attom: { avm, profile, sales }, housecanary: { value: hcValue, rent: hcRent, forecast: hcForecast } });
+});
 
 // The corridor screen: run all official layers for a point in one shot —
 // the boom-signal test (policy ∩ entitlements ∩ pipeline) plus crime context.


### PR DESCRIPTION
Turns the wired-but-headless ATTOM/HouseCanary connectors into a usable tool.

## What's included
- **`/api/live/diligence`** — one endpoint that runs ATTOM (AVM + owner/records + sales history) and HouseCanary (value + rent AVM + 3-yr forecast) in parallel for a single address. Each provider degrades independently, so a missing HouseCanary secret still returns the full ATTOM half.
- **DealDiligence panel** in the Deal Room — enter any US address (listing, resale, or off-market home), click Run, and see all six results with headline numbers and raw-JSON expanders (resilient to varying provider response shapes until field formatting is tuned against live data).

## Security
- The ATTOM/HC routes **and** the new `/diligence` aggregate are now **loopback-gated** (`privateLocalOnly`). They consume paid API keys and ATTOM returns owner PII, so they're private-tier only — never reachable from the public static site.

## Verification
- Endpoint returns correct per-provider `ok:false` reasons with keys unset; gating returns 404 when `ALLOW_PRIVATE_LOCAL` is off
- Panel renders and runs in the Deal Room (verified in-browser)
- Privacy tests 4/4; client build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_