### PR TITLE
HouseCanary: surface no-match responses as a clear reason

### DIFF
--- a/server/src/liveapis.js
+++ b/server/src/liveapis.js
@@ -238,7 +238,21 @@ async function hcCall(target, address, zipcode) {
 const hcResult = (r, target) => {
   if (!r.ok) return r;
   const item = Array.isArray(r.data) ? r.data[0] : r.data;
-  return { ok: true, source: `HouseCanary ${target}`, result: item?.[`property/${target}`]?.result ?? item };
+  const envelope = item?.[`property/${target}`];
+  // A matched property nests its payload under `property/<target>`. When
+  // HouseCanary has no record for the address (common for brand-new
+  // construction not yet in county/MLS feeds), that key is absent and the
+  // top-level envelope carries only an api_code/description instead.
+  if (envelope) return { ok: true, source: `HouseCanary ${target}`, result: envelope.result ?? envelope };
+  const desc = item?.api_code_description || 'no data';
+  const code = item?.api_code;
+  const matched = item?.address_info?.status?.match;
+  return {
+    ok: false,
+    reason: matched === false
+      ? `HouseCanary has no record for this address yet (common for brand-new construction not yet in county/MLS data) — "${desc}"${code != null ? ` (code ${code})` : ''}.`
+      : `HouseCanary: "${desc}"${code != null ? ` (code ${code})` : ''}.`,
+  };
 };
 
 async function hcValue(address, zipcode) { return hcResult(await hcCall('value', address, zipcode), 'value'); }


### PR DESCRIPTION
## Summary
- The diligence panel's HouseCanary cards showed `api_code: 204`, `match: false`, and other raw diagnostic fields under a bare "—" instead of a plain explanation, because `hcResult()` always returned `ok: true` and fell back to the whole raw envelope when a property wasn't matched.
- `hcResult()` now checks for the actual `property/<target>` payload; if absent, it returns `ok: false` with a plain-English reason (calling out that HouseCanary likely has no record yet for brand-new construction), which the existing amber-alert UI in `DealDiligence.jsx` already renders correctly.

## Test plan
- [x] Reviewed the raw HouseCanary response shape from the reported screenshot (`api_code_description: "no content"`, `address_info.status.match: false`) to confirm the new branch condition matches it
- [ ] User to re-run diligence for 3912 Craig Ave and confirm HouseCanary cards now show a clear "no record yet" message instead of raw fields
- [ ] User to re-run diligence for an established (non-new-construction) address to confirm the success path (real value/rent/forecast numbers) still renders correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_