### PR TITLE
Remove synthetic fallback listings; make price-cut stat honest

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -163,7 +163,12 @@ export default function App() {
     }
   }
 
-  const priceCutListings = listings.filter(l => l.original_price > 0 && l.price < l.original_price);
+  // A listing counts as reduced if the source reported a higher original
+  // price, or if we watched the price drop ourselves (tracked history).
+  const priceCutListings = listings.filter(l =>
+    (l.original_price > 0 && l.price < l.original_price)
+    || (l.price_history?.length > 0 && l.price < l.price_history[l.price_history.length - 1].price)
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -238,7 +243,7 @@ export default function App() {
               <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
                 <span className="text-sm font-semibold text-red-700">
-                  {priceCutListings.length} listing{priceCutListings.length !== 1 ? 's' : ''} with price cuts today!
+                  {priceCutListings.length} active price reduction{priceCutListings.length !== 1 ? 's' : ''}
                 </span>
                 <button
                   onClick={() => setFilters(f => ({ ...f, priceCut: true }))}

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -121,6 +121,22 @@ db.exec(`
 // Migration: leaseback flag for model-home sale-leaseback opportunities
 try { db.exec('ALTER TABLE listings ADD COLUMN leaseback INTEGER DEFAULT 0'); } catch { /* exists */ }
 
+// Migration: purge synthetic sample listings. Early scraper versions fell back
+// to hardcoded fake data when a portal/builder blocked them; those rows (and
+// their baked-in "price cuts") polluted stats. Real scraped ids end in an MD5
+// hex slice, so these patterns only ever match the numbered sample rows.
+// GLOB is used because '_' is a wildcard in LIKE.
+{
+  const sampleCond = `
+    id GLOB 'zillow_sample_*' OR id GLOB 'realtor_sample_*' OR
+    id GLOB 'nhs_sample_*' OR id GLOB 'opendoor_sample_*' OR
+    id GLOB 'homes_s[0-9]*' OR id GLOB 'builder_*_[0-9]'
+  `;
+  db.prepare(`DELETE FROM price_history WHERE listing_id IN (SELECT id FROM listings WHERE ${sampleCond})`).run();
+  const purged = db.prepare(`DELETE FROM listings WHERE ${sampleCond}`).run().changes;
+  if (purged > 0) console.log(`[DB] Purged ${purged} synthetic sample listings`);
+}
+
 const { enrichListing } = require('./market');
 const { listingArt } = require('./listingArt');
 
@@ -226,7 +242,14 @@ function getListings(filters = {}) {
   if (filters.minPrice) { query += ' AND l.price >= ?'; params.push(filters.minPrice); }
   if (filters.maxPrice) { query += ' AND l.price <= ?'; params.push(filters.maxPrice); }
   if (filters.beds) { query += ' AND l.beds >= ?'; params.push(filters.beds); }
-  if (filters.priceCut) { query += ' AND l.price < l.original_price AND l.original_price > 0'; }
+  if (filters.priceCut) {
+    // Same reduction rule as getStats: source-reported original price, or a
+    // drop we observed ourselves via tracked price history.
+    query += ` AND (
+      (l.price < l.original_price AND l.original_price > 0)
+      OR l.price < (SELECT ph.price FROM price_history ph WHERE ph.listing_id = l.id ORDER BY ph.id DESC LIMIT 1)
+    )`;
+  }
   if (filters.isModel) { query += ' AND l.is_model = 1'; }
   if (filters.furnished) { query += ' AND l.is_furnished = 1'; }
   if (filters.leaseback) { query += ' AND l.leaseback = 1'; }
@@ -260,7 +283,15 @@ function getListings(filters = {}) {
 function getStats() {
   return {
     total: db.prepare('SELECT COUNT(*) as c FROM listings WHERE is_active=1').get().c,
-    price_cuts: db.prepare('SELECT COUNT(*) as c FROM listings WHERE is_active=1 AND price < original_price AND original_price > 0').get().c,
+    // Active price reductions: the source reported a higher original price,
+    // or we observed the price drop ourselves (latest tracked prior price is
+    // above the current one). Not "cuts today" — a running total.
+    price_cuts: db.prepare(`
+      SELECT COUNT(*) as c FROM listings l WHERE l.is_active=1 AND (
+        (l.original_price > 0 AND l.price < l.original_price)
+        OR l.price < (SELECT ph.price FROM price_history ph WHERE ph.listing_id = l.id ORDER BY ph.id DESC LIMIT 1)
+      )
+    `).get().c,
     new_today: db.prepare("SELECT COUNT(*) as c FROM listings WHERE is_active=1 AND date(created_at) = date('now')").get().c,
     avg_price: db.prepare('SELECT AVG(price) as a FROM listings WHERE is_active=1 AND price > 0').get().a,
     by_source: db.prepare('SELECT source, COUNT(*) as count FROM listings WHERE is_active=1 GROUP BY source').all(),

--- a/server/src/liveapis.js
+++ b/server/src/liveapis.js
@@ -238,7 +238,21 @@ async function hcCall(target, address, zipcode) {
 const hcResult = (r, target) => {
   if (!r.ok) return r;
   const item = Array.isArray(r.data) ? r.data[0] : r.data;
-  return { ok: true, source: `HouseCanary ${target}`, result: item?.[`property/${target}`]?.result ?? item };
+  const envelope = item?.[`property/${target}`];
+  // A matched property nests its payload under `property/<target>`. When
+  // HouseCanary has no record for the address (common for brand-new
+  // construction not yet in county/MLS feeds), that key is absent and the
+  // top-level envelope carries only an api_code/description instead.
+  if (envelope) return { ok: true, source: `HouseCanary ${target}`, result: envelope.result ?? envelope };
+  const desc = item?.api_code_description || 'no data';
+  const code = item?.api_code;
+  const matched = item?.address_info?.status?.match;
+  return {
+    ok: false,
+    reason: matched === false
+      ? `HouseCanary has no record for this address yet (common for brand-new construction not yet in county/MLS data) — "${desc}"${code != null ? ` (code ${code})` : ''}.`
+      : `HouseCanary: "${desc}"${code != null ? ` (code ${code})` : ''}.`,
+  };
 };
 
 async function hcValue(address, zipcode) { return hcResult(await hcCall('value', address, zipcode), 'value'); }

--- a/server/src/publicSnapshot.js
+++ b/server/src/publicSnapshot.js
@@ -30,7 +30,12 @@ function summarize(listings, generatedAt) {
 
   return {
     total: listings.length,
-    price_cuts: listings.filter(listing => listing.original_price > 0 && listing.price < listing.original_price).length,
+    // Same rule as getStats/App.jsx: source-reported reduction, or a drop we
+    // observed ourselves in tracked price history.
+    price_cuts: listings.filter(listing =>
+      (listing.original_price > 0 && listing.price < listing.original_price)
+      || (listing.price_history?.length > 0 && listing.price < listing.price_history[listing.price_history.length - 1].price)
+    ).length,
     new_today: listings.filter(listing => String(listing.created_at || '').slice(0, 10) === today).length,
     avg_price: prices.length ? prices.reduce((sum, price) => sum + price, 0) / prices.length : null,
     by_source: countBy(listings, 'source'),

--- a/server/src/scrapers/builders/index.js
+++ b/server/src/scrapers/builders/index.js
@@ -44,29 +44,14 @@ async function scrapeDRHorton() {
       is_new_construction: 1,
       move_in_date: h.moveInDate || h.estimatedCompletion || null,
     }));
-  } catch {
-    return getDRHortonFallback();
+  } catch (err) {
+    // Builder APIs shift or block bots — log it and return nothing rather
+    // than synthetic listings. Only real inventory belongs in the DB.
+    console.error('[D.R. Horton] scrape error:', err.message);
+    return [];
   }
 }
 
-function getDRHortonFallback() {
-  return [
-    { addr: '4215 Tuckaseegee Rd', city: 'Charlotte', zip: '28208', price: 272000, orig: 285000, beds: 3, baths: 2.5, sqft: 1395, community: 'West Charlotte Townes', phone: '(704) 887-1234' },
-    { addr: '9023 Rocky River Rd', city: 'Charlotte', zip: '28215', price: 305000, orig: null, beds: 3, baths: 2.5, sqft: 1542, community: 'Rocky River Crossings', phone: '(704) 887-1234' },
-    { addr: '1811 Westinghouse Blvd', city: 'Charlotte', zip: '28273', price: 291000, orig: 304000, beds: 3, baths: 2.5, sqft: 1476, community: 'Steele Creek Run', phone: '(704) 887-1234' },
-  ].map((l, i) => ({
-    id: `builder_drhorton_${i + 1}`,
-    source: 'drhorton',
-    url: 'https://www.drhorton.com/north-carolina/charlotte',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'D.R. Horton', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['Open concept', 'Smart home package', '1-car garage', 'Patio'],
-  }));
-}
 
 // --- Lennar ---
 async function scrapeLennar() {
@@ -98,30 +83,14 @@ async function scrapeLennar() {
       status: 'for_sale',
       is_new_construction: 1,
     }));
-  } catch {
-    return getLennarFallback();
+  } catch (err) {
+    // Builder APIs shift or block bots — log it and return nothing rather
+    // than synthetic listings. Only real inventory belongs in the DB.
+    console.error('[Lennar] scrape error:', err.message);
+    return [];
   }
 }
 
-function getLennarFallback() {
-  return [
-    { addr: '8245 Arrowood Rd', city: 'Charlotte', zip: '28273', price: 309000, orig: null, beds: 3, baths: 2.5, sqft: 1548, community: 'Arrowood Towns', phone: '(980) 224-5678' },
-    { addr: '415 Griffith Lakes Dr', city: 'Charlotte', zip: '28269', price: 338000, orig: 352000, beds: 3, baths: 3, sqft: 1698, community: 'Griffith Lakes', phone: '(980) 224-5678' },
-    { addr: '105 Canopy Oaks Ln', city: 'Concord', zip: '28027', price: 295000, orig: null, beds: 3, baths: 2.5, sqft: 1490, community: 'Canopy Oaks', phone: '(980) 224-5678' },
-    { addr: '3414 Beatties Ford Rd', city: 'Charlotte', zip: '28216', price: 278000, orig: 290000, beds: 3, baths: 2.5, sqft: 1398, community: 'Sterling Pointe', phone: '(980) 224-5678' },
-  ].map((l, i) => ({
-    id: `builder_lennar_${i + 1}`,
-    source: 'lennar',
-    url: 'https://www.lennar.com/new-homes/north-carolina/charlotte',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'Lennar', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['Stainless appliances', 'Granite counters', 'Ring doorbell', 'Wi-Fi certified'],
-  }));
-}
 
 // --- Ryan Homes ---
 async function scrapeRyanHomes() {
@@ -145,29 +114,14 @@ async function scrapeRyanHomes() {
       phone: c.salesPhone || null,
       type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
     }));
-  } catch {
-    return getRyanHomesFallback();
+  } catch (err) {
+    // Builder APIs shift or block bots — log it and return nothing rather
+    // than synthetic listings. Only real inventory belongs in the DB.
+    console.error('[Ryan Homes] scrape error:', err.message);
+    return [];
   }
 }
 
-function getRyanHomesFallback() {
-  return [
-    { addr: '122 Walnut Creek Blvd', city: 'Matthews', zip: '28105', price: 372000, orig: 388000, beds: 3, baths: 2.5, sqft: 1765, community: 'Walnut Creek Townes', phone: '(704) 814-9900' },
-    { addr: '5701 Albemarle Rd', city: 'Charlotte', zip: '28212', price: 318000, orig: null, beds: 3, baths: 2.5, sqft: 1580, community: 'Albemarle Commons', phone: '(704) 814-9900' },
-    { addr: '2345 Lawyers Rd', city: 'Mint Hill', zip: '28227', price: 349000, orig: 362000, beds: 4, baths: 3, sqft: 1870, community: 'Mint Hill Commons', phone: '(704) 814-9900' },
-  ].map((l, i) => ({
-    id: `builder_ryanhomes_${i + 1}`,
-    source: 'ryanhomes',
-    url: 'https://www.ryanhomes.com/find-a-home/nc/charlotte-area',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'Ryan Homes', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['Quartz counters', 'LVP flooring', 'Stainless appliances', 'Rear-load garage'],
-  }));
-}
 
 // --- Meritage Homes ---
 async function scrapeMeritage() {
@@ -187,29 +141,14 @@ async function scrapeMeritage() {
       phone: c.salesPhone || null,
       type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
     }));
-  } catch {
-    return getMeritageFallback();
+  } catch (err) {
+    // Builder APIs shift or block bots — log it and return nothing rather
+    // than synthetic listings. Only real inventory belongs in the DB.
+    console.error('[Meritage] scrape error:', err.message);
+    return [];
   }
 }
 
-function getMeritageFallback() {
-  return [
-    { addr: '12200 Copper Way', city: 'Huntersville', zip: '28078', price: 419000, orig: null, beds: 3, baths: 3, sqft: 1985, community: 'Birkdale Pointe', phone: '(704) 992-6100' },
-    { addr: '21901 Torrence Chapel Rd', city: 'Cornelius', zip: '28031', price: 498000, orig: 515000, beds: 4, baths: 3.5, sqft: 2245, community: 'The Cove at Cornelius', phone: '(704) 992-6100' },
-    { addr: '18045 W Catawba Ave', city: 'Cornelius', zip: '28031', price: 459000, orig: null, beds: 3, baths: 3, sqft: 2025, community: 'Peninsula Crossing', phone: '(704) 992-6100' },
-  ].map((l, i) => ({
-    id: `builder_meritage_${i + 1}`,
-    source: 'meritage',
-    url: 'https://www.meritagehomes.com/state/nc/charlotte-area',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'Meritage Homes', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['Energy Star certified', 'Solar ready', 'Spray foam insulation', 'Smart thermostat'],
-  }));
-}
 
 // --- Eastwood Homes (Charlotte-based) ---
 async function scrapeEastwoodHomes() {
@@ -226,50 +165,14 @@ async function scrapeEastwoodHomes() {
       price: h.price || 0, builder: 'Eastwood Homes', community: h.community,
       phone: '(704) 376-9700', type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
     }));
-  } catch {
-    return getEastwoodFallback();
+  } catch (err) {
+    // Builder APIs shift or block bots — log it and return nothing rather
+    // than synthetic listings. Only real inventory belongs in the DB.
+    console.error('[Eastwood] scrape error:', err.message);
+    return [];
   }
 }
 
-function getEastwoodFallback() {
-  return [
-    { addr: '5034 Reedy Creek Rd', city: 'Charlotte', zip: '28215', price: 334000, orig: 349000, beds: 3, baths: 2.5, sqft: 1652, community: 'Reedy Creek Reserve', phone: '(704) 376-9700' },
-    { addr: '7128 Idlewild Rd', city: 'Charlotte', zip: '28212', price: 298000, orig: null, beds: 3, baths: 2.5, sqft: 1498, community: 'Idlewild Commons', phone: '(704) 376-9700' },
-    { addr: '6804 Albemarle Rd', city: 'Charlotte', zip: '28212', price: 319000, orig: 332000, beds: 3, baths: 3, sqft: 1585, community: 'Albemarle Townes', phone: '(704) 376-9700' },
-    { addr: '2812 Rea Rd', city: 'Charlotte', zip: '28226', price: 489000, orig: null, beds: 4, baths: 3.5, sqft: 2180, community: 'Rea Farms Village', phone: '(704) 376-9700' },
-  ].map((l, i) => ({
-    id: `builder_eastwood_${i + 1}`,
-    source: 'eastwood',
-    url: 'https://www.eastwoodhomes.com/charlotte',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'Eastwood Homes', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['10-year structural warranty', 'Gas fireplace option', 'Tankless water heater', '2-car garage'],
-  }));
-}
-
-// --- Smith Douglas Homes ---
-function getSmithDouglasFallback() {
-  return [
-    { addr: '7015 Wallace Neel Rd', city: 'Charlotte', zip: '28214', price: 269000, orig: null, beds: 3, baths: 2.5, sqft: 1365, community: 'Steele Creek Point', phone: '(704) 944-0180' },
-    { addr: '4912 Sunset Rd', city: 'Charlotte', zip: '28269', price: 289000, orig: 299000, beds: 3, baths: 2.5, sqft: 1448, community: 'University Townes', phone: '(704) 944-0180' },
-    { addr: '3125 Freedom Dr', city: 'Charlotte', zip: '28208', price: 258000, orig: null, beds: 3, baths: 2, sqft: 1298, community: 'Freedom Commons', phone: '(704) 944-0180' },
-  ].map((l, i) => ({
-    id: `builder_smdi_${i + 1}`,
-    source: 'smithdouglas',
-    url: 'https://www.smithdouglashomes.com/communities/?state=north-carolina',
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city, state: 'NC', zip: l.zip,
-    price: l.price, original_price: l.orig,
-    beds: l.beds, baths: l.baths, sqft: l.sqft,
-    builder: 'Smith Douglas Homes', community: l.community, phone: l.phone,
-    type: 'Townhome', status: 'for_sale', is_new_construction: 1, images: [],
-    features: ['Standard granite', 'Subway tile', 'Vinyl plank floors', 'Patio'],
-  }));
-}
 
 async function scrapeAllBuilders() {
   const [drHorton, lennar, ryanHomes, meritage, eastwood] = await Promise.allSettled([
@@ -282,7 +185,6 @@ async function scrapeAllBuilders() {
     ...(ryanHomes.status === 'fulfilled' ? ryanHomes.value : []),
     ...(meritage.status === 'fulfilled' ? meritage.value : []),
     ...(eastwood.status === 'fulfilled' ? eastwood.value : []),
-    ...getSmithDouglasFallback(),
   ];
 }
 

--- a/server/src/scrapers/homes.js
+++ b/server/src/scrapers/homes.js
@@ -50,47 +50,18 @@ async function scrapeHomes() {
       });
     });
 
-    return results.length > 0 ? results : getFallbackHomesData();
+    // An empty result set usually means Homes.com changed their markup or
+    // served a bot wall — report reality instead of inventing listings.
+    return results;
   } catch (err) {
     console.error('[Homes] scrape error:', err.message);
-    return getFallbackHomesData();
+    return [];
   }
 }
 
 function extractCity(address) {
   const match = address.match(/,\s*([^,]+),\s*[A-Z]{2}/);
   return match ? match[1].trim() : 'Charlotte';
-}
-
-function getFallbackHomesData() {
-  return [
-    { id: 'homes_s1', city: 'Charlotte', zip: '28278', addr: '15012 Shopton Rd W', price: 319000, beds: 3, baths: 2.5, sqft: 1565, builder: 'D.R. Horton', community: 'Shopton Farms' },
-    { id: 'homes_s2', city: 'Concord', zip: '28027', addr: '2801 Cabarrus Ave NW', price: 287000, beds: 3, baths: 2.5, sqft: 1480, builder: 'Ryan Homes', community: 'Cabarrus Station' },
-    { id: 'homes_s3', city: 'Indian Land', zip: '29707', addr: '6245 Sun Valley Dr', price: 359000, beds: 3, baths: 3, sqft: 1795, builder: 'Lennar', community: 'Sun Valley Towns' },
-    { id: 'homes_s4', city: 'Mint Hill', zip: '28227', addr: '13221 Lawyers Rd', price: 395000, beds: 4, baths: 3.5, sqft: 2095, builder: 'Eastwood Homes', community: 'Mint Hill Townes' },
-    { id: 'homes_s5', city: 'Gastonia', zip: '28054', addr: '4412 Robinwood Rd', price: 249000, beds: 3, baths: 2, sqft: 1355, builder: 'Century Communities', community: 'Robinwood Commons' },
-    { id: 'homes_s6', city: 'Waxhaw', zip: '28173', addr: '901 Waxhaw-Marvin Rd', price: 468000, beds: 4, baths: 3.5, sqft: 2280, builder: 'Taylor Morrison', community: 'Elm Lane' },
-  ].map((l, i) => ({
-    id: l.id,
-    source: 'homes',
-    url: `https://www.homes.com/property/charlotte-nc-${i + 1}`,
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city,
-    state: 'NC',
-    zip: l.zip,
-    price: l.price,
-    original_price: i % 3 === 1 ? l.price + 18000 : null,
-    beds: l.beds,
-    baths: l.baths,
-    sqft: l.sqft,
-    type: 'Townhome',
-    status: 'for_sale',
-    builder: l.builder,
-    community: l.community,
-    images: [],
-    days_on_market: 8 + i * 3,
-    is_new_construction: 1,
-  }));
 }
 
 module.exports = { scrapeHomes };

--- a/server/src/scrapers/newhomesource.js
+++ b/server/src/scrapers/newhomesource.js
@@ -68,57 +68,18 @@ async function scrapeNewHomeSource() {
       });
     });
 
-    return results.length > 0 ? results : getFallbackNHSData();
+    // An empty result set means the page structure changed or a bot wall was
+    // served — report reality instead of inventing listings.
+    return results;
   } catch (err) {
     console.error('[NewHomeSource] scrape error:', err.message);
-    return getFallbackNHSData();
+    return [];
   }
 }
 
 function extractCity(address) {
   const parts = address.split(',');
   return parts.length > 1 ? parts[parts.length - 2].trim().replace(/\s+[A-Z]{2}$/, '') : 'Charlotte';
-}
-
-function getFallbackNHSData() {
-  const communities = [
-    { addr: '6145 Trade St', city: 'Charlotte', zip: '28269', price: 315000, orig: 330000, beds: 3, baths: 2.5, sqft: 1595, builder: 'Smith Douglas Homes', community: 'University Research Park Townes', phone: '(704) 555-0101' },
-    { addr: '119 Langtree Village Dr', city: 'Mooresville', zip: '28117', price: 445000, orig: null, beds: 4, baths: 3.5, sqft: 2250, builder: 'David Weekley Homes', community: 'Langtree at the Lake', phone: '(704) 555-0102' },
-    { addr: '3011 Johnston Oehler Rd', city: 'Charlotte', zip: '28269', price: 299000, orig: 312000, beds: 3, baths: 2.5, sqft: 1510, builder: 'D.R. Horton', community: 'Mallard Pointe', phone: '(704) 555-0103' },
-    { addr: '6789 Statesville Rd', city: 'Charlotte', zip: '28269', price: 289000, orig: null, beds: 3, baths: 2, sqft: 1425, builder: 'Century Communities', community: 'Highland Ridge', phone: '(704) 555-0104' },
-    { addr: '224 Morrison Blvd', city: 'Charlotte', zip: '28211', price: 599000, orig: 625000, beds: 4, baths: 4, sqft: 2650, builder: 'Toll Brothers', community: 'SouthPark Urban', phone: '(704) 555-0105' },
-    { addr: '1045 Gilead Rd', city: 'Huntersville', zip: '28078', price: 389000, orig: null, beds: 3, baths: 3, sqft: 1850, builder: 'Pulte Homes', community: 'Birkdale Station', phone: '(704) 555-0106' },
-    { addr: '4512 Wilkinson Blvd', city: 'Charlotte', zip: '28208', price: 275000, orig: 289000, beds: 3, baths: 2.5, sqft: 1398, builder: 'Ryan Homes', community: 'West End Commons', phone: '(704) 555-0107' },
-    { addr: '18901 W Catawba Ave', city: 'Cornelius', zip: '28031', price: 519000, orig: null, beds: 4, baths: 3.5, sqft: 2380, builder: 'Meritage Homes', community: 'The Peninsula Townes', phone: '(704) 555-0108' },
-    { addr: '11823 Copper Springs Rd', city: 'Charlotte', zip: '28213', price: 348000, orig: 362000, beds: 3, baths: 2.5, sqft: 1680, builder: 'Eastwood Homes', community: 'Copper Springs', phone: '(704) 555-0109' },
-    { addr: '4901 Nations Ford Rd', city: 'Charlotte', zip: '28217', price: 261000, orig: null, beds: 3, baths: 2, sqft: 1320, builder: 'Lennar', community: 'Steele Creek Towns', phone: '(704) 555-0110' },
-    { addr: '2209 Matthews Mint Hill Rd', city: 'Matthews', zip: '28105', price: 412000, orig: 430000, beds: 4, baths: 3, sqft: 2010, builder: 'M/I Homes', community: 'Matthews Station', phone: '(704) 555-0111' },
-    { addr: '7234 Beatties Ford Rd', city: 'Charlotte', zip: '28216', price: 308000, orig: null, beds: 3, baths: 2.5, sqft: 1560, builder: 'Beazer Homes', community: 'Beatties Ford Commons', phone: '(704) 555-0112' },
-  ];
-
-  return communities.map((l, i) => ({
-    id: `nhs_sample_${i + 1}`,
-    source: 'newhomesource',
-    url: `https://www.newhomesource.com/community/sample-${i + 1}`,
-    address: `${l.addr}, ${l.city}, NC ${l.zip}`,
-    city: l.city,
-    state: 'NC',
-    zip: l.zip,
-    price: l.price,
-    original_price: l.orig,
-    beds: l.beds,
-    baths: l.baths,
-    sqft: l.sqft,
-    type: 'Townhome',
-    status: 'for_sale',
-    builder: l.builder,
-    community: l.community,
-    phone: l.phone,
-    images: [],
-    days_on_market: 5 + i * 4,
-    is_new_construction: 1,
-    features: ['Smart thermostat', 'Hardwood floors', 'Granite counters', 'Attached 1-car garage'],
-  }));
 }
 
 module.exports = { scrapeNewHomeSource, CHARLOTTE_BUILDERS };

--- a/server/src/scrapers/opendoor.js
+++ b/server/src/scrapers/opendoor.js
@@ -51,50 +51,10 @@ async function scrapeOpendoor() {
       description: h.description || null,
     }));
   } catch (err) {
+    // Return nothing on failure — only real inventory belongs in the DB.
     console.error('[Opendoor] scrape error:', err.message);
-    return getFallbackOpendoorData();
+    return [];
   }
-}
-
-function getFallbackOpendoorData() {
-  return [
-    {
-      id: 'opendoor_sample_1',
-      source: 'opendoor',
-      url: 'https://www.opendoor.com/homes/charlotte-nc-sample-1',
-      address: '4218 Rozzelles Ferry Rd, Charlotte, NC 28216',
-      city: 'Charlotte', state: 'NC', zip: '28216',
-      price: 289000, original_price: 305000,
-      beds: 3, baths: 2.5, sqft: 1480,
-      type: 'Townhome', status: 'for_sale',
-      builder: 'Opendoor',
-      images: [], days_on_market: 14, is_new_construction: 0,
-    },
-    {
-      id: 'opendoor_sample_2',
-      source: 'opendoor',
-      url: 'https://www.opendoor.com/homes/charlotte-nc-sample-2',
-      address: '7701 Caldwell Rd, Huntersville, NC 28078',
-      city: 'Huntersville', state: 'NC', zip: '28078',
-      price: 342000, original_price: 359000,
-      beds: 3, baths: 3, sqft: 1720,
-      type: 'Townhome', status: 'for_sale',
-      builder: 'Opendoor',
-      images: [], days_on_market: 7, is_new_construction: 0,
-    },
-    {
-      id: 'opendoor_sample_3',
-      source: 'opendoor',
-      url: 'https://www.opendoor.com/homes/charlotte-nc-sample-3',
-      address: '2214 Somersby Blvd, Indian Land, SC 29707',
-      city: 'Indian Land', state: 'SC', zip: '29707',
-      price: 398000, original_price: null,
-      beds: 4, baths: 3.5, sqft: 2050,
-      type: 'Townhome', status: 'for_sale',
-      builder: 'Opendoor',
-      images: [], days_on_market: 3, is_new_construction: 0,
-    },
-  ];
 }
 
 module.exports = { scrapeOpendoor };

--- a/server/src/scrapers/realtor.js
+++ b/server/src/scrapers/realtor.js
@@ -77,43 +77,11 @@ async function scrapeRealtor() {
       };
     });
   } catch (err) {
+    // Realtor.com's internal API moved/blocks bots (404). Return nothing
+    // rather than synthetic listings — only real inventory belongs in the DB.
     console.error('[Realtor] scrape error:', err.message);
-    return getFallbackRealtorData();
+    return [];
   }
-}
-
-function getFallbackRealtorData() {
-  const listings = [
-    { addr: '5201 Nolen Ave', city: 'Charlotte', zip: '28209', price: 419000, beds: 3, baths: 3.5, sqft: 1890, builder: 'Taylor Morrison', community: 'SouthPark Townes' },
-    { addr: '204 Walnut Creek Ct', city: 'Matthews', zip: '28105', price: 375000, beds: 3, baths: 2.5, sqft: 1720, builder: 'Ryan Homes', community: 'Walnut Creek' },
-    { addr: '8811 Magnolia Estates Dr', city: 'Cornelius', zip: '28031', price: 489000, beds: 4, baths: 3.5, sqft: 2100, builder: 'Meritage Homes', community: 'Magnolia Estates' },
-    { addr: '3301 Prosperity Church Rd', city: 'Charlotte', zip: '28269', price: 329000, beds: 3, baths: 2.5, sqft: 1580, builder: 'Smith Douglas Homes', community: 'Prosperity Village' },
-    { addr: '12450 Providence Rd', city: 'Charlotte', zip: '28277', price: 550000, beds: 4, baths: 3.5, sqft: 2400, builder: 'Toll Brothers', community: 'Providence Townes' },
-    { addr: '2901 Sandy Porter Rd', city: 'Charlotte', zip: '28273', price: 298000, beds: 3, baths: 2.5, sqft: 1520, builder: 'Century Communities', community: 'Steele Creek Commons' },
-  ];
-
-  return listings.map((l, i) => ({
-    id: `realtor_sample_${i + 1}`,
-    source: 'realtor',
-    url: `https://www.realtor.com/realestateandhomes-detail/sample-${i + 1}`,
-    address: `${l.addr}, ${l.city}, ${l.zip}`,
-    city: l.city,
-    state: 'NC',
-    zip: l.zip,
-    price: l.price,
-    original_price: i % 4 === 0 ? l.price + 20000 : null,
-    beds: l.beds,
-    baths: l.baths,
-    sqft: l.sqft,
-    type: 'Townhome',
-    status: 'for_sale',
-    builder: l.builder,
-    community: l.community,
-    images: [],
-    days_on_market: 10 + i * 5,
-    is_new_construction: 1,
-    features: ['Smart home features', 'Energy efficient', 'Quartz countertops', 'Walk-in closet'],
-  }));
 }
 
 module.exports = { scrapeRealtor };

--- a/server/src/scrapers/zillow.js
+++ b/server/src/scrapers/zillow.js
@@ -70,8 +70,10 @@ async function scrapeZillow() {
       is_new_construction: 1,
     }));
   } catch (err) {
+    // Zillow blocks bot traffic (403) most of the time. Return nothing rather
+    // than synthetic listings — the grid should only ever show real inventory.
     console.error('[Zillow] scrape error:', err.message);
-    return getFallbackZillowData();
+    return [];
   }
 }
 
@@ -83,49 +85,6 @@ function extractCity(address) {
 function parsePrice(str) {
   if (!str) return 0;
   return parseInt(str.toString().replace(/[^0-9]/g, '')) || 0;
-}
-
-// Realistic sample data for when scraping is blocked
-function getFallbackZillowData() {
-  const communities = [
-    { name: 'Baxter Village', city: 'Fort Mill', builder: 'Eastwood Homes', lat: 35.0058, lng: -80.9451 },
-    { name: 'Waverly', city: 'Charlotte', builder: 'David Weekley', lat: 35.0393, lng: -80.8065 },
-    { name: 'Traditions at Sardis', city: 'Charlotte', builder: 'Smith Douglas', lat: 35.1845, lng: -80.7234 },
-    { name: 'Birkdale Village', city: 'Huntersville', builder: 'Meritage Homes', lat: 35.4168, lng: -80.8578 },
-    { name: 'Berewick', city: 'Charlotte', builder: 'Lennar', lat: 35.1401, lng: -80.9678 },
-    { name: 'Skybrook', city: 'Huntersville', builder: 'Ryan Homes', lat: 35.4052, lng: -80.8234 },
-    { name: 'Griffith Lakes', city: 'Charlotte', builder: 'D.R. Horton', lat: 35.3456, lng: -80.7891 },
-    { name: 'The Commons at Ballantyne', city: 'Charlotte', builder: 'Pulte Homes', lat: 35.0567, lng: -80.8234 },
-  ];
-
-  return communities.map((c, i) => {
-    const basePrice = 320000 + i * 25000;
-    const hasCut = i % 3 === 0;
-    return {
-      id: `zillow_sample_${i + 1}`,
-      source: 'zillow',
-      url: `https://www.zillow.com/homedetails/charlotte-nc-${i + 1}`,
-      address: `${1000 + i * 100} ${['Oak', 'Maple', 'Cedar', 'Pine', 'Birch', 'Willow', 'Elm', 'Ash'][i]} Lane, ${c.city}, NC ${28200 + i}`,
-      city: c.city,
-      state: 'NC',
-      zip: `${28200 + i}`,
-      price: hasCut ? basePrice - 15000 : basePrice,
-      original_price: hasCut ? basePrice : null,
-      beds: 3 + (i % 2),
-      baths: 2.5,
-      sqft: 1650 + i * 80,
-      type: 'Townhome',
-      status: 'FOR_SALE',
-      builder: c.builder,
-      community: c.name,
-      images: [`https://photos.zillowstatic.com/fp/sample${i + 1}.jpg`],
-      latitude: c.lat,
-      longitude: c.lng,
-      days_on_market: 5 + i * 3,
-      is_new_construction: 1,
-      features: ['Granite counters', 'Stainless appliances', 'Attached garage', 'Open floor plan'],
-    };
-  });
 }
 
 module.exports = { scrapeZillow };


### PR DESCRIPTION
## Summary
- **Every scraped-source listing in the DB was synthetic.** All portal scrapers (Zillow, Realtor.com, Homes.com, NewHomeSource, Opendoor) *and* all builder scrapers fell back to hardcoded sample data when the live fetch failed — and the builder catch blocks were silent, so the log reported success. None of the live scrapes ever succeeded; 55 of 80 active rows were fake, with baked-in "price cuts" that froze the price-cut banner at the same number every day.
- Scrapers now return `[]` on failure/empty and always log the error. The Smith Douglas fallback that was appended unconditionally (even on success) is removed entirely.
- `db.js` gains an idempotent startup migration purging the synthetic rows and their `price_history` children. GLOB patterns target the numbered sample ids, which can't collide with real MD5-slice ids.
- The price-cut stat, the `priceCut` filter, the public snapshot, and the client banner all use one rule: a reduction counts only when the source reported a higher original price **or** we observed the drop ourselves in tracked price history. Banner text changes from "N listings with price cuts today!" to "N active price reductions".

## Test plan
- [x] All scraper modules parse and load after fallback removal
- [x] Live smoke test: Zillow + all builder scrapers fail (403) → return 0 listings with visible error logs, no synthetic rows
- [x] Startup migration against a copy of the real DB: purged 55 synthetic listings; 25 real remain (16 model homes + 9 Gmail); `price_cuts` drops 31 → 6 genuine reductions; `priceCut` filter agrees (6); zero leftover synthetic ids
- [x] `vite build` passes with the App.jsx banner change
- [ ] User: pull + restart, confirm log prints `[DB] Purged 55 synthetic sample listings` once, listings grid shows ~25 real entries, banner reads "active price reductions"


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_