### PR TITLE
RentCast price-cut scanner, headless builder scrapers, My Deals, tours import

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ import {
   fetchTracked, saveTracked, deleteTracked, fetchMarket, fetchResearch, fetchBuilderProfiles,
 } from './api';
 import { IS_STATIC } from './staticData';
+import RentCastScan from './components/RentCastScan';
 
 const PUBLIC_TABS = [
   { id: 'listings', label: 'Listings', icon: LayoutGrid },
@@ -238,6 +239,13 @@ export default function App() {
 
         {tab === 'listings' && (
           <>
+            {/* Manual RentCast sweep (private tier only — metered free API) */}
+            {!IS_STATIC && (
+              <div className="mb-4 flex items-center flex-wrap">
+                <RentCastScan onScanned={() => { loadListings(); loadMeta(); }} />
+              </div>
+            )}
+
             {/* Price cut highlight bar */}
             {priceCutListings.length > 0 && (
               <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl flex items-center gap-3">

--- a/client/src/components/DealRoom.jsx
+++ b/client/src/components/DealRoom.jsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { Lock, Unlock, ShieldAlert, Calculator } from 'lucide-react';
+import { useState, useMemo, useEffect } from 'react';
+import { Lock, Unlock, ShieldAlert, Calculator, Plus, Briefcase, X, Loader2 } from 'lucide-react';
 import { IS_STATIC } from '../staticData';
 import DealDocuments from './DealDocuments';
 import DealDiligence from './DealDiligence';
@@ -48,8 +48,89 @@ function StaticStub() {
   );
 }
 
+// "My Deals": every deal gets its own document vault. The list + create flow
+// hit loopback-gated routes, so this whole strip only exists on the private tier.
+function MyDeals({ deals, active, onSelect, onCreated }) {
+  const [adding, setAdding] = useState(false);
+  const [form, setForm] = useState({ title: '', address: '' });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  async function create() {
+    if (!form.title.trim() && !form.address.trim()) return;
+    setBusy(true); setErr('');
+    try {
+      const r = await fetch('/api/deals', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(form),
+      });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.error || 'Could not create deal');
+      setAdding(false);
+      setForm({ title: '', address: '' });
+      onCreated(j.deal);
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Briefcase className="w-4 h-4 text-blue-600" />
+        <h3 className="text-sm font-semibold text-gray-800">My Deals</h3>
+        <button onClick={() => setAdding(a => !a)}
+          className="ml-auto inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-blue-600 border border-blue-200 hover:bg-blue-50 rounded-lg">
+          <Plus className="w-3.5 h-3.5" /> New deal
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {deals.map(deal => (
+          <button key={deal.slug} onClick={() => onSelect(deal.slug)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition ${
+              deal.slug === active ? 'bg-blue-600 text-white border-blue-600' : 'text-gray-600 border-gray-200 hover:bg-gray-50'}`}>
+            {deal.title}
+          </button>
+        ))}
+        {deals.length === 0 && <p className="text-xs text-gray-400">No deals yet — add your first.</p>}
+      </div>
+      {adding && (
+        <div className="mt-3 flex flex-wrap gap-2 items-center">
+          <input value={form.title} onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
+            placeholder="Deal name (e.g. 123 Main St)" onKeyDown={e => e.key === 'Enter' && create()}
+            className="flex-1 min-w-[180px] px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <input value={form.address} onChange={e => setForm(f => ({ ...f, address: e.target.value }))}
+            placeholder="Full address (optional)" onKeyDown={e => e.key === 'Enter' && create()}
+            className="flex-1 min-w-[200px] px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <button onClick={create} disabled={busy || (!form.title.trim() && !form.address.trim())}
+            className="px-3 py-1.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 flex items-center gap-1">
+            {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />} Create
+          </button>
+          <button onClick={() => setAdding(false)} className="p-1.5 text-gray-400 hover:text-gray-600"><X className="w-4 h-4" /></button>
+        </div>
+      )}
+      {err && <p className="text-xs text-red-600 mt-2">{err}</p>}
+    </section>
+  );
+}
+
 export default function DealRoom({ market, research }) {
   const [d, setD] = useState({ address: '', price: 400000, incentive: 0, rent: 2500, leaseMonths: 12, hoa: 250, taxAnnual: 3100, sqft: 1600 });
+  const [deals, setDeals] = useState([]);
+  const [activeSlug, setActiveSlug] = useState('3912-craig-ave');
+
+  useEffect(() => {
+    if (IS_STATIC) return;
+    fetch('/api/deals')
+      .then(r => r.json())
+      .then(j => {
+        const list = j.deals || [];
+        setDeals(list);
+        if (list.length && !list.some(x => x.slug === '3912-craig-ave')) setActiveSlug(list[0].slug);
+      })
+      .catch(() => {});
+  }, []);
 
   const assumptions = market?.assumptions;
   // Benchmark comes from the private research file, served only over loopback.
@@ -128,11 +209,21 @@ export default function DealRoom({ market, research }) {
         </section>
       </div>
 
-      {/* Per-deal document vault: local uploads + Drive index (private tier) */}
-      {/* Live property diligence: ATTOM + HouseCanary for any address (paid keys) */}
+      {/* Live property diligence: ATTOM + RentCast + HouseCanary for any address */}
       <DealDiligence />
 
-      <DealDocuments slug="3912-craig-ave" title={yd?.property?.split('—')[0]?.trim() || '3912 Craig Ave'} />
+      {/* Deal picker + create; each deal gets its own document vault */}
+      <MyDeals
+        deals={deals.length ? deals : [{ slug: '3912-craig-ave', title: yd?.property?.split('—')[0]?.trim() || '3912 Craig Ave' }]}
+        active={activeSlug}
+        onSelect={setActiveSlug}
+        onCreated={deal => { setDeals(ds => [...ds.filter(x => x.slug !== deal.slug), deal].sort((a, b) => a.slug.localeCompare(b.slug))); setActiveSlug(deal.slug); }}
+      />
+
+      <DealDocuments
+        slug={activeSlug}
+        title={deals.find(x => x.slug === activeSlug)?.title || (activeSlug === '3912-craig-ave' ? (yd?.property?.split('—')[0]?.trim() || '3912 Craig Ave') : activeSlug)}
+      />
     </div>
   );
 }

--- a/client/src/components/RentCastScan.jsx
+++ b/client/src/components/RentCastScan.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { Radar, Loader2, X, TrendingDown } from 'lucide-react';
+
+// Manual RentCast sweep of Mecklenburg + Gaston townhomes. Deliberately not
+// automated: the free tier is 50 calls/month, so every scan shows a cost
+// preview and asks before spending. Private tier only (loopback route).
+export default function RentCastScan({ onScanned }) {
+  const [preview, setPreview] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState(null);
+  const [err, setErr] = useState('');
+
+  async function openPreview() {
+    setErr(''); setResult(null); setBusy(true);
+    try {
+      const r = await fetch('/api/live/rentcast-scan/preview');
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.reason || 'Preview failed');
+      setPreview(j);
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runScan() {
+    setBusy(true); setErr('');
+    try {
+      const r = await fetch('/api/live/rentcast-scan', { method: 'POST' });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.reason || 'Scan failed');
+      setResult(j);
+      setPreview(null);
+      onScanned?.();
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <button onClick={openPreview} disabled={busy}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-purple-700 border border-purple-200 hover:bg-purple-50 rounded-lg disabled:opacity-50"
+        title="Sweep Mecklenburg + Gaston active townhomes via RentCast (metered)">
+        {busy && !preview ? <Loader2 className="w-4 h-4 animate-spin" /> : <Radar className="w-4 h-4" />}
+        Scan price cuts
+      </button>
+
+      {err && <span className="text-xs text-red-600 ml-2">{err}</span>}
+
+      {result && (
+        <span className="inline-flex items-center gap-1 text-xs text-green-700 bg-green-50 border border-green-200 rounded-lg px-2 py-1 ml-2">
+          <TrendingDown className="w-3 h-3" />
+          {result.inScope} listings, {result.priceCuts} with cuts · {result.callsSpent} call{result.callsSpent === 1 ? '' : 's'} spent · {result.remaining}/{result.limit} left this month
+        </span>
+      )}
+
+      {preview && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={() => setPreview(null)}>
+          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-5" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-lg font-bold text-gray-900">RentCast sweep</h3>
+              <button onClick={() => setPreview(null)} className="p-1.5 rounded-full hover:bg-gray-100"><X className="w-5 h-5 text-gray-500" /></button>
+            </div>
+            <p className="text-sm text-gray-600 mb-3">
+              Active townhomes across <strong>Mecklenburg + Gaston</strong> ({preview.region.radiusMiles}-mile radius),
+              with real per-listing price-drop history.
+            </p>
+            <div className="text-sm bg-gray-50 rounded-lg p-3 space-y-1">
+              <div className="flex justify-between"><span className="text-gray-500">Cost of this scan</span><span className="font-semibold">up to {preview.maxCalls} API calls</span></div>
+              <div className="flex justify-between"><span className="text-gray-500">Used this month</span><span className="font-semibold">{preview.used} / {preview.limit}</span></div>
+              <div className="flex justify-between"><span className="text-gray-500">Remaining after scan</span><span className="font-semibold">≥ {Math.max(0, preview.remaining - preview.maxCalls)}</span></div>
+            </div>
+            <p className="text-[11px] text-gray-400 mt-2">{preview.note}</p>
+            <div className="flex gap-2 mt-4">
+              <button onClick={runScan} disabled={busy || preview.remaining < 1}
+                className="flex-1 py-2 text-sm font-semibold text-white bg-purple-600 hover:bg-purple-700 rounded-lg disabled:opacity-50 flex items-center justify-center gap-1.5">
+                {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Radar className="w-4 h-4" />}
+                {preview.remaining < 1 ? 'Budget exhausted' : 'Run scan'}
+              </button>
+              <button onClick={() => setPreview(null)} className="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-50 rounded-lg">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -269,6 +269,23 @@ app.get('/api/live/diligence', privateLocalOnly, async (req, res) => {
   });
 });
 
+// --- RentCast two-county price-cut scanner (manual trigger, metered) ---
+const rentcastScan = require('./src/rentcastScan');
+
+// Zero-cost preview: budget used/remaining and what a scan would spend.
+app.get('/api/live/rentcast-scan/preview', privateLocalOnly, (req, res) => {
+  res.json({ ok: true, ...rentcastScan.scanPreview() });
+});
+
+app.post('/api/live/rentcast-scan', privateLocalOnly, async (req, res) => {
+  try {
+    const result = await rentcastScan.runScan();
+    res.status(result.ok ? 200 : 400).json(result);
+  } catch (err) {
+    res.status(500).json({ ok: false, reason: err.message });
+  }
+});
+
 // The corridor screen: run all official layers for a point in one shot —
 // the boom-signal test (policy ∩ entitlements ∩ pipeline) plus crime context.
 app.get('/api/live/corridor', async (req, res) => {
@@ -299,7 +316,12 @@ const upload = multer({
 });
 
 app.get('/api/deals', privateLocalOnly, (req, res) => {
-  try { res.json({ deals: dealFiles.listDeals() }); } catch (err) { res.status(500).json({ error: err.message }); }
+  try { res.json({ deals: dealFiles.listDealsWithMeta() }); } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+// Create a new deal (title/address → slug + empty vault dir).
+app.post('/api/deals', privateLocalOnly, (req, res) => {
+  try { res.json({ ok: true, deal: dealFiles.createDeal(req.body || {}) }); } catch (err) { res.status(400).json({ ok: false, error: err.message }); }
 });
 
 app.get('/api/deals/:slug/files', privateLocalOnly, (req, res) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.19.2",
         "multer": "^2.2.0",
         "node-cron": "^3.0.3",
+        "playwright": "^1.54.0",
         "user-agents": "^1.1.228"
       },
       "devDependencies": {
@@ -1634,6 +1635,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prebuild-install": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "scrape:headless": "node scripts/test-headless.js",
+    "import:tours": "node scripts/import-tours.js"
   },
   "dependencies": {
     "axios": "^1.7.2",
@@ -15,7 +17,8 @@
     "express": "^4.19.2",
     "multer": "^2.2.0",
     "node-cron": "^3.0.3",
-    "user-agents": "^1.1.228"
+    "user-agents": "^1.1.228",
+    "playwright": "^1.54.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.4"

--- a/server/scripts/import-tours.js
+++ b/server/scripts/import-tours.js
@@ -1,0 +1,30 @@
+// Import tour entries into My Tours (tracked_places):
+//   cd server && npm run import:tours -- path/to/tours-seed.json
+//
+// The seed file is private (tour history is personal data) and is never
+// committed — this script is the generic loader. Entries are matched by
+// address: existing places are left untouched, so re-running is safe.
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { db, saveTrackedPlace } = require('../src/db');
+
+const seedPath = process.argv[2];
+if (!seedPath) {
+  console.error('Usage: npm run import:tours -- path/to/tours-seed.json');
+  process.exit(1);
+}
+
+const seed = JSON.parse(fs.readFileSync(path.resolve(seedPath), 'utf8'));
+const places = seed.places || [];
+let added = 0, skipped = 0;
+
+for (const p of places) {
+  const existing = db.prepare('SELECT id FROM tracked_places WHERE address = ?').get(p.address);
+  if (existing) { skipped++; continue; }
+  saveTrackedPlace(p);
+  added++;
+  console.log(`+ ${p.address} (${p.status || 'considering'})`);
+}
+
+console.log(`\nDone: ${added} added, ${skipped} already present.`);

--- a/server/scripts/test-headless.js
+++ b/server/scripts/test-headless.js
@@ -1,0 +1,23 @@
+// Manual test-drive for the headless builder scrapers:
+//   cd server && npm run scrape:headless
+// Prints what each site yields without touching the database.
+require('dotenv').config();
+const { scrapeHeadlessBuilders } = require('../src/scrapers/headless');
+
+(async () => {
+  console.log('Running headless builder scrape (David Weekley, Lennar, Tri Pointe, Mungo)...\n');
+  const listings = await scrapeHeadlessBuilders();
+  const bySource = {};
+  for (const l of listings) (bySource[l.source] ||= []).push(l);
+  for (const [source, ls] of Object.entries(bySource)) {
+    console.log(`\n== ${source} — ${ls.length} listings ==`);
+    for (const l of ls.slice(0, 10)) {
+      console.log(`  $${(l.price || 0).toLocaleString().padEnd(9)} ${l.address}${l.community ? `  (${l.community})` : ''}`);
+    }
+    if (ls.length > 10) console.log(`  ...and ${ls.length - 10} more`);
+  }
+  if (!listings.length) {
+    console.log('No listings extracted. If playwright is missing, run: npm install');
+  }
+  process.exit(0);
+})();

--- a/server/src/aggregate.js
+++ b/server/src/aggregate.js
@@ -4,6 +4,7 @@ const { scrapeOpendoor } = require('./scrapers/opendoor');
 const { scrapeNewHomeSource } = require('./scrapers/newhomesource');
 const { scrapeHomes } = require('./scrapers/homes');
 const { scrapeAllBuilders } = require('./scrapers/builders');
+const { scrapeHeadlessBuilders } = require('./scrapers/headless');
 const { searchEmails } = require('./gmail');
 const { upsertListing, logScrape, markStaleListings, db } = require('./db');
 const fs = require('fs');
@@ -22,13 +23,21 @@ function loadGmailListings() {
   }
 }
 
-// Curated model-home / furnished / leaseback opportunities
+// Curated model-home / furnished / leaseback opportunities.
+// Four early entries were traced back to fabricated sample data (their
+// addresses match the old scraper fallbacks and the communities don't
+// exist as named) — filter them even if an older data file is in place.
+const FABRICATED_MODEL_IDS = new Set([
+  'model_lennar_sterling_pointe', 'model_drh_mallard_pointe',
+  'model_sd_university_townes', 'model_century_gastonia',
+]);
+
 function loadModelHomes() {
   const file = path.join(__dirname, '..', 'data', 'model-homes.json');
   try {
     if (!fs.existsSync(file)) return [];
     const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
-    return (raw.listings || []).filter(l => l.id && l.address);
+    return (raw.listings || []).filter(l => l.id && l.address && !FABRICATED_MODEL_IDS.has(l.id));
   } catch (err) {
     console.error('[Aggregate] Could not read model-homes.json:', err.message);
     return [];
@@ -44,6 +53,9 @@ const SOURCES = [
   { name: 'newhomesource', fn: scrapeNewHomeSource, label: 'NewHomeSource' },
   { name: 'homes', fn: scrapeHomes, label: 'Homes.com' },
   { name: 'builders', fn: scrapeAllBuilders, label: 'Builder Sites' },
+  // Real-browser scrapes of David Weekley / Lennar / Tri Pointe / Mungo —
+  // these sites block plain HTTP or render inventory with JavaScript.
+  { name: 'headless', fn: scrapeHeadlessBuilders, label: 'Builder Sites (headless)' },
 ];
 
 async function runAllScrapers() {

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -116,6 +116,14 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_listings_active ON listings(is_active);
   CREATE INDEX IF NOT EXISTS idx_price_history_listing ON price_history(listing_id);
   CREATE INDEX IF NOT EXISTS idx_tracked_status ON tracked_places(status);
+
+  -- Metered-API call accounting (e.g. RentCast free tier = 50 calls/month).
+  CREATE TABLE IF NOT EXISTS api_usage (
+    provider TEXT NOT NULL,
+    month TEXT NOT NULL,          -- 'YYYY-MM'
+    calls INTEGER DEFAULT 0,
+    PRIMARY KEY (provider, month)
+  );
 `);
 
 // Migration: leaseback flag for model-home sale-leaseback opportunities
@@ -130,7 +138,8 @@ try { db.exec('ALTER TABLE listings ADD COLUMN leaseback INTEGER DEFAULT 0'); } 
   const sampleCond = `
     id GLOB 'zillow_sample_*' OR id GLOB 'realtor_sample_*' OR
     id GLOB 'nhs_sample_*' OR id GLOB 'opendoor_sample_*' OR
-    id GLOB 'homes_s[0-9]*' OR id GLOB 'builder_*_[0-9]'
+    id GLOB 'homes_s[0-9]*' OR id GLOB 'builder_*_[0-9]' OR
+    id IN ('model_lennar_sterling_pointe','model_drh_mallard_pointe','model_sd_university_townes','model_century_gastonia')
   `;
   db.prepare(`DELETE FROM price_history WHERE listing_id IN (SELECT id FROM listings WHERE ${sampleCond})`).run();
   const purged = db.prepare(`DELETE FROM listings WHERE ${sampleCond}`).run().changes;
@@ -451,7 +460,23 @@ function getTrackedStats() {
   };
 }
 
+// Metered-API accounting: count calls per provider per calendar month so
+// free-tier budgets (RentCast: 50/mo) are visible and never silently blown.
+function bumpApiUsage(provider, n = 1) {
+  const month = new Date().toISOString().slice(0, 7);
+  db.prepare(`
+    INSERT INTO api_usage (provider, month, calls) VALUES (?, ?, ?)
+    ON CONFLICT(provider, month) DO UPDATE SET calls = calls + excluded.calls
+  `).run(provider, month, n);
+}
+
+function getApiUsage(provider) {
+  const month = new Date().toISOString().slice(0, 7);
+  return db.prepare('SELECT calls FROM api_usage WHERE provider = ? AND month = ?').get(provider, month)?.calls || 0;
+}
+
 module.exports = {
   db, upsertListing, getListings, getStats, logScrape, getScrapeLogs, markStaleListings,
   saveTrackedPlace, getTrackedPlaces, getTrackedIds, deleteTrackedPlace, getTrackedStats, TRACK_STATUSES,
+  bumpApiUsage, getApiUsage,
 };

--- a/server/src/dealFiles.js
+++ b/server/src/dealFiles.js
@@ -43,6 +43,51 @@ function listDeals() {
     .map(e => e.name);
 }
 
+// Deal metadata (title/address per slug) lives in deals.json at the vault
+// root — private like everything else here.
+const DEALS_META = path.join(ROOT, 'deals.json');
+
+function readDealsMeta() {
+  try { return JSON.parse(fs.readFileSync(DEALS_META, 'utf8')); } catch { return {}; }
+}
+
+function writeDealsMeta(meta) {
+  fs.mkdirSync(ROOT, { recursive: true });
+  fs.writeFileSync(DEALS_META, JSON.stringify(meta, null, 2));
+}
+
+// Slug from a human title/address: "3912 Craig Ave" → "3912-craig-ave".
+function slugify(text) {
+  return safeSlug(String(text || '').toLowerCase().trim()
+    .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60));
+}
+
+// Every deal the vault knows about: directories on disk merged with saved
+// metadata, so deals created before metadata existed still show up.
+function listDealsWithMeta() {
+  const meta = readDealsMeta();
+  const slugs = new Set([...listDeals(), ...Object.keys(meta)]);
+  return [...slugs].sort().map(slug => ({
+    slug,
+    title: meta[slug]?.title || slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+    address: meta[slug]?.address || null,
+    created_at: meta[slug]?.created_at || null,
+  }));
+}
+
+function createDeal({ title, address }) {
+  const name = String(title || address || '').trim();
+  if (!name) throw new Error('Deal needs a title or address');
+  const slug = slugify(name);
+  ensureDealDir(slug);
+  const meta = readDealsMeta();
+  if (!meta[slug]) {
+    meta[slug] = { title: name, address: String(address || '').trim() || null, created_at: new Date().toISOString() };
+    writeDealsMeta(meta);
+  }
+  return { slug, ...meta[slug] };
+}
+
 function listDealFiles(slug) {
   const dir = dealDir(slug);
   let uploads = [];
@@ -76,4 +121,7 @@ function deleteFile(slug, name) {
   return true;
 }
 
-module.exports = { ROOT, safeSlug, safeName, ensureDealDir, listDeals, listDealFiles, filePath, deleteFile };
+module.exports = {
+  ROOT, safeSlug, safeName, ensureDealDir, listDeals, listDealFiles, filePath, deleteFile,
+  listDealsWithMeta, createDeal,
+};

--- a/server/src/rentcastScan.js
+++ b/server/src/rentcastScan.js
@@ -1,0 +1,152 @@
+// RentCast active-listings scanner — the legal replacement for the dead
+// portal scrapers. One /listings/sale call returns up to 500 active listings
+// with per-listing price history, so a full Mecklenburg + Gaston townhome
+// sweep costs ~2-4 calls of the free tier's 50/month.
+//
+// Every call is metered in the api_usage table, and runScan() refuses to
+// start if the sweep wouldn't fit in the remaining monthly budget. The scan
+// is manual-trigger only (no cron) for the same reason.
+const axios = require('axios');
+const crypto = require('crypto');
+const { upsertListing, bumpApiUsage, getApiUsage, logScrape } = require('./db');
+
+const MONTHLY_LIMIT = parseInt(process.env.RENTCAST_MONTHLY_LIMIT || '50', 10);
+const PAGE_SIZE = 500;      // RentCast max per request
+const MAX_PAGES = 4;        // hard cap so a bug can never drain the budget
+
+// One radius covers both target counties: centered between Charlotte and
+// Gastonia, 30mi reaches all of Mecklenburg + Gaston (plus fringes of
+// neighboring counties, which the allow-list filters back out).
+const SCAN_REGION = {
+  latitude: 35.26,
+  longitude: -80.95,
+  radiusMiles: 30,
+  counties: ['Mecklenburg', 'Gaston'],
+  propertyType: 'Townhouse',
+};
+
+function makeId(rcId) {
+  return `rentcast_${crypto.createHash('md5').update(String(rcId)).digest('hex').slice(0, 12)}`;
+}
+
+// A listing's history is an object keyed by ISO date, each entry carrying an
+// event and price. If any prior recorded price is above the current asking
+// price, that's a real observed reduction.
+function priorHighPrice(listing) {
+  const events = Object.values(listing.history || {});
+  const prices = events.map(e => e.price).filter(p => p > 0);
+  const high = Math.max(...prices, 0);
+  return high > (listing.price || 0) ? high : null;
+}
+
+function toListing(r) {
+  return {
+    id: makeId(r.id || r.formattedAddress),
+    source: 'rentcast',
+    url: `https://app.rentcast.io/app?address=${encodeURIComponent(r.formattedAddress || '')}`,
+    address: r.formattedAddress || '',
+    city: r.city || '',
+    state: r.state || 'NC',
+    zip: r.zipCode || '',
+    price: r.price || 0,
+    original_price: priorHighPrice(r),
+    beds: r.bedrooms ?? null,
+    baths: r.bathrooms ?? null,
+    sqft: r.squareFootage ?? null,
+    year_built: r.yearBuilt ?? null,
+    type: 'Townhome',
+    status: r.status || 'Active',
+    builder: r.builder || null,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    days_on_market: r.daysOnMarket ?? null,
+    is_new_construction: r.yearBuilt && r.yearBuilt >= new Date().getFullYear() - 1 ? 1 : 0,
+    images: [],
+  };
+}
+
+function usage() {
+  const used = getApiUsage('rentcast');
+  return { used, limit: MONTHLY_LIMIT, remaining: Math.max(0, MONTHLY_LIMIT - used) };
+}
+
+// Zero-cost preview: what a scan would spend vs. what's left this month.
+function scanPreview() {
+  return {
+    region: SCAN_REGION,
+    maxCalls: MAX_PAGES,
+    ...usage(),
+    note: `A full sweep uses 1 call per ${PAGE_SIZE} listings (max ${MAX_PAGES}). Metro townhome inventory typically fits in 1-2 calls.`,
+  };
+}
+
+async function runScan() {
+  if (!process.env.RENTCAST_API_KEY) {
+    return { ok: false, reason: 'RENTCAST_API_KEY not set (free key: rentcast.io/api)' };
+  }
+  const { remaining } = usage();
+  if (remaining < 1) {
+    return { ok: false, reason: `RentCast monthly budget exhausted (${MONTHLY_LIMIT}/${MONTHLY_LIMIT} calls used). Resets next month.` };
+  }
+  const budget = Math.min(MAX_PAGES, remaining);
+
+  let calls = 0;
+  const found = [];
+  try {
+    for (let page = 0; page < budget; page++) {
+      const resp = await axios.get('https://api.rentcast.io/v1/listings/sale', {
+        params: {
+          latitude: SCAN_REGION.latitude,
+          longitude: SCAN_REGION.longitude,
+          radius: SCAN_REGION.radiusMiles,
+          propertyType: SCAN_REGION.propertyType,
+          status: 'Active',
+          limit: PAGE_SIZE,
+          offset: page * PAGE_SIZE,
+        },
+        headers: { 'X-Api-Key': process.env.RENTCAST_API_KEY },
+        timeout: 20000,
+      });
+      calls++;
+      bumpApiUsage('rentcast', 1);
+      const batch = Array.isArray(resp.data) ? resp.data : [];
+      found.push(...batch);
+      if (batch.length < PAGE_SIZE) break; // last page
+    }
+  } catch (err) {
+    if (calls > 0) bumpApiUsage('rentcast', 0); // usage already counted per successful call
+    const status = err.response?.status;
+    const detail = err.response?.data?.message || err.message;
+    logScrape('rentcast', 'error', { found: found.length }, detail);
+    return { ok: false, reason: status === 403 ? `RentCast rejected the key: ${detail}` : `RentCast error: ${detail}`, callsSpent: calls };
+  }
+
+  // Keep only the two target counties; the radius unavoidably catches
+  // neighbors (Union, Cabarrus, York SC) which we drop here.
+  const inScope = found.filter(r => {
+    const county = String(r.county || '').replace(/ county/i, '').trim();
+    return SCAN_REGION.counties.some(c => county.toLowerCase() === c.toLowerCase());
+  });
+
+  let created = 0, updated = 0, cuts = 0;
+  for (const r of inScope) {
+    const listing = toListing(r);
+    if (listing.original_price) cuts++;
+    const { action } = upsertListing(listing);
+    if (action === 'created') created++; else updated++;
+  }
+  logScrape('rentcast', 'success', { found: inScope.length, created, updated });
+
+  return {
+    ok: true,
+    callsSpent: calls,
+    fetched: found.length,
+    inScope: inScope.length,
+    created,
+    updated,
+    priceCuts: cuts,
+    ...usage(),
+  };
+}
+
+module.exports = { scanPreview, runScan, SCAN_REGION };

--- a/server/src/scrapers/headless/index.js
+++ b/server/src/scrapers/headless/index.js
@@ -1,0 +1,202 @@
+// Headless-browser scrapers for builder sites that block plain HTTP or
+// render listings with JavaScript. Builders advertise this inventory
+// publicly and use little bot protection, unlike the consumer portals.
+//
+// Playwright is loaded lazily: if it isn't installed the source degrades to
+// an empty result with a clear log line instead of crashing the pipeline.
+// Extraction is layered for resilience against redesigns:
+//   1. schema.org JSON-LD blocks (most builder sites embed these)
+//   2. framework state (__NEXT_DATA__ / __NUXT__)
+//   3. DOM heuristics: cards containing both a $price and an address-ish line
+const crypto = require('crypto');
+
+const NAV_TIMEOUT = 30000;
+const PER_SITE_BUDGET = 60000; // total ms per site, so one slow site can't stall the run
+
+function makeId(source, key) {
+  return `${source}_${crypto.createHash('md5').update(String(key)).digest('hex').slice(0, 12)}`;
+}
+
+function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch {
+    console.error('[Headless] playwright not installed — run `npm install` in server/ (first install downloads a browser)');
+    return null;
+  }
+}
+
+async function launch(pw) {
+  const opts = { headless: true };
+  // Sandboxed environments route egress through a proxy; a real Mac won't
+  // have HTTPS_PROXY set and launches directly.
+  if (process.env.HTTPS_PROXY) opts.proxy = { server: process.env.HTTPS_PROXY };
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) opts.executablePath = process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  return pw.chromium.launch(opts);
+}
+
+// ---- extraction layers -----------------------------------------------------
+
+// JSON-LD: builder pages commonly embed Product/SingleFamilyResidence/Offer
+// nodes with name, address, and price.
+function fromJsonLd(blocks) {
+  const out = [];
+  const walk = node => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(walk);
+    const type = String(node['@type'] || '');
+    const price = node.offers?.price ?? node.price ?? null;
+    const addr = node.address;
+    if ((/Residence|Product|House|Apartment|Accommodation/i.test(type)) && (price || addr)) {
+      out.push({
+        name: node.name || '',
+        price: parseInt(String(price || '').replace(/[^0-9]/g, '')) || null,
+        street: addr?.streetAddress || '',
+        city: addr?.addressLocality || '',
+        state: addr?.addressRegion || '',
+        zip: addr?.postalCode || '',
+        url: node.url || node.offers?.url || null,
+        beds: node.numberOfBedrooms ?? null,
+        baths: node.numberOfBathroomsTotal ?? node.numberOfFullBathrooms ?? null,
+        sqft: parseInt(String(node.floorSize?.value || '').replace(/[^0-9]/g, '')) || null,
+      });
+    }
+    Object.values(node).forEach(walk);
+  };
+  blocks.forEach(b => { try { walk(JSON.parse(b)); } catch { /* malformed block */ } });
+  return out;
+}
+
+// DOM heuristic run inside the page: find repeated card-like elements that
+// contain both a price and something address-shaped.
+const DOM_HARVEST = `
+(() => {
+  const priceRe = /\\$\\s?([2-9]\\d{2}[,.]?\\d{3})/;
+  const addrRe = /\\d{2,5}\\s+[A-Z][A-Za-z]+.{0,40}(?:NC|SC|\\d{5})|\\d{2,5}\\s+[A-Z][A-Za-z]+\\s+(?:St|Ave|Dr|Rd|Ln|Ct|Way|Blvd|Trl|Pl)\\b/;
+  const seen = new Set();
+  const cards = [];
+  for (const el of document.querySelectorAll('a[href], article, li, div')) {
+    const t = (el.innerText || '').trim();
+    if (t.length < 20 || t.length > 600) continue;
+    const pm = t.match(priceRe);
+    const am = t.match(addrRe);
+    if (!pm || !am) continue;
+    const key = am[0] + pm[1];
+    if (seen.has(key)) continue;
+    // prefer the innermost matching element: skip if a child already matched
+    if (cards.some(c => el.contains(c.el))) continue;
+    seen.add(key);
+    const link = el.closest('a[href]')?.href || el.querySelector('a[href]')?.href || location.href;
+    cards.push({ el, text: t.slice(0, 400), price: pm[1], address: am[0], url: link });
+  }
+  return cards.map(({ text, price, address, url }) => ({ text, price, address, url }));
+})()
+`;
+
+async function harvestPage(page, url) {
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT });
+  await page.waitForTimeout(4000); // let client-side rendering settle
+  const ld = await page.$$eval('script[type="application/ld+json"]', els => els.map(e => e.textContent));
+  const structured = fromJsonLd(ld);
+  if (structured.length) return { items: structured, via: 'json-ld' };
+  const cards = await page.evaluate(DOM_HARVEST);
+  return {
+    items: cards.map(c => ({
+      name: '',
+      price: parseInt(String(c.price).replace(/[^0-9]/g, '')) || null,
+      street: c.address, city: '', state: '', zip: '',
+      url: c.url, beds: null, baths: null, sqft: null,
+    })),
+    via: 'dom',
+  };
+}
+
+// ---- per-builder configs ---------------------------------------------------
+
+const SITES = [
+  {
+    source: 'davidweekley', builder: 'David Weekley Homes',
+    urls: ['https://www.davidweekleyhomes.com/new-homes/nc/charlotte'],
+  },
+  {
+    source: 'lennar', builder: 'Lennar',
+    urls: ['https://www.lennar.com/new-homes/north-carolina/charlotte'],
+  },
+  {
+    source: 'tripointe', builder: 'Tri Pointe Homes',
+    urls: ['https://www.tripointehomes.com/nc/charlotte/'],
+  },
+  {
+    source: 'mungo', builder: 'Mungo Homes',
+    urls: ['https://www.mungo.com/communities/charlotte/charlotte-nc'],
+  },
+];
+
+function toListing(site, item, pageUrl) {
+  const address = [item.street, item.city, item.state, item.zip].filter(Boolean).join(', ') || item.name;
+  if (!address || !item.price) return null;
+  return {
+    id: makeId(site.source, address),
+    source: site.source,
+    url: item.url || pageUrl,
+    address,
+    city: item.city || 'Charlotte',
+    state: item.state || 'NC',
+    zip: item.zip || '',
+    price: item.price,
+    beds: item.beds, baths: item.baths, sqft: item.sqft,
+    type: 'Townhome',
+    status: 'for_sale',
+    builder: site.builder,
+    community: item.name || null,
+    images: [],
+    is_new_construction: 1,
+  };
+}
+
+async function scrapeHeadlessBuilders() {
+  const pw = loadPlaywright();
+  if (!pw) return [];
+
+  let browser;
+  try {
+    browser = await launch(pw);
+  } catch (err) {
+    console.error('[Headless] browser launch failed:', err.message);
+    return [];
+  }
+
+  const results = [];
+  try {
+    for (const site of SITES) {
+      const started = Date.now();
+      const page = await browser.newPage({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+      });
+      try {
+        for (const url of site.urls) {
+          if (Date.now() - started > PER_SITE_BUDGET) break;
+          const { items, via } = await harvestPage(page, url);
+          const listings = items.map(i => toListing(site, i, url)).filter(Boolean);
+          console.log(`[Headless] ${site.builder}: ${listings.length} listings via ${via} (${url})`);
+          results.push(...listings);
+        }
+      } catch (err) {
+        console.error(`[Headless] ${site.builder} failed:`, err.message);
+      } finally {
+        await page.close().catch(() => {});
+      }
+    }
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  // De-dupe across pages by id
+  const byId = new Map();
+  for (const l of results) byId.set(l.id, l);
+  return [...byId.values()];
+}
+
+// harvestPage/fromJsonLd/toListing exported for the fixture tests in
+// server/scripts — not part of the scraping API.
+module.exports = { scrapeHeadlessBuilders, SITES, harvestPage, fromJsonLd, toListing, launch, loadPlaywright };


### PR DESCRIPTION
## Summary
- **RentCast two-county price-cut scanner** — manual radius sweep (30 mi, Mecklenburg + Gaston allow-list) of active townhomes via `/listings/sale`, with real per-listing price-drop history feeding `original_price`. Every call is metered in a new `api_usage` table; the Listings-tab button shows a zero-cost preview (used/remaining of the 50-calls/mo free tier) and requires confirmation before spending. Hard 4-page cap so a bug can never drain the budget.
- **Headless builder scrapers** — Playwright drives a real Chrome against David Weekley, Lennar, Tri Pointe, and Mungo (sites that block plain HTTP or render inventory with JS). Layered extraction: schema.org JSON-LD first, DOM price+address heuristics as fallback. Playwright loads lazily and the source degrades to empty-with-log if missing. New `npm run scrape:headless` test-drive script.
- **My Deals** — deals metadata + `POST /api/deals`; Deal Room gains a deal picker and create form, each deal getting its own private document vault.
- **Tours importer** — `npm run import:tours -- <seed.json>` loads tour entries into tracked_places, idempotent by address (seed file stays private, outside the repo).
- **Data hygiene** — model-homes loader filters four entries traced to fabricated sample data (e.g. "Mallard Pointe" doesn't exist; the real community is Mallard Creek Townhomes), and the startup purge deletes their DB rows.

## Test plan
- [x] `vite build` passes; all new/changed server modules parse
- [x] Scan preview + no-key scan failure return clean JSON (live server test)
- [x] Deal create/list round-trip verified via curl (then cleaned up)
- [x] Tours import: 4 places added, re-run skips all 4 (idempotent)
- [x] Headless: browser launches, per-site failures degrade gracefully; both extraction layers verified against local JSON-LD and DOM fixtures
- [ ] User (Mac): `npm install` in server/, `npm run scrape:headless` against the real sites
- [ ] User: activate RentCast plan, run "Scan price cuts" from Listings tab


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw2FzYEaNeikMZu5Qb9kEe)_